### PR TITLE
Fix check notes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,4 +4,6 @@
 ^codecov\.yml$
 ^_pkgdown\.yml$
 ^pkgdown$
+^LICENSE\.md$
 ^LICENSES_THIRD_PARTY\.md$
+^README\.Rmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,18 +1,23 @@
 Package: psm3mkv
-Title: Fit and Evaluate Three-State Partitioned Survival Analysis and Markov Models to Progression-Free and Overall Survival data
+Title: Fit and Evaluate Three-State Partitioned Survival Analysis and Markov Models to Progression-Free and Overall Survival Data
 Version: 0.1.0
 Authors@R: c(
     person("Dominic", "Muston", , "dominic.muston@merck.com", role = c("aut", "cre"),
-           comment = c(ORCID = "0000000348767940")),
+           comment = c(ORCID = "0000-0003-4876-7940")),
     person("Merck & Co., Inc.", role = c("cph", "fnd"))
     )
-Description: Fits and evaluates three-state partitioned survival analyses (PartSAs) and markov models (clock forward or clock reset) to Progression-Free Survival (PFS) and Overall Survival (OS) patient-level data. This data is typically collected in clinical trials in oncology. These model structures are typically considered in cost-effectiveness modeling in advanced/metastatic cancer indications.
+Description: Fits and evaluates three-state partitioned survival analyses
+    (PartSAs) and markov models (clock forward or clock reset) to
+    Progression-Free Survival (PFS) and Overall Survival (OS)
+    patient-level data. This data is typically collected in clinical trials
+    in oncology. These model structures are typically considered in
+    cost-effectiveness modeling in advanced/metastatic cancer indications.
 License: GPL (>= 3)
+URL: https://merck.github.io/psm3mkv/, https://github.com/Merck/psm3mkv
+BugReports: https://github.com/Merck/psm3mkv/issues
 Encoding: UTF-8
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
 Depends: R (>= 4.1.0)
-Imports: 
+Imports:
     dplyr,
     flexsurv,
     ggplot2,
@@ -24,11 +29,14 @@ Imports:
     SurvMetrics,
     tibble,
     tidyr
-Suggests: 
+Suggests:
+    boot,
     covr,
+    ggsci,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)
-Config/testthat/edition: 3
 VignetteBuilder: knitr
-URL: https://github.com/Merck/psm3mkv
+Config/testthat/edition: 3
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.3

--- a/man/psm3mkv-package.Rd
+++ b/man/psm3mkv-package.Rd
@@ -4,7 +4,7 @@
 \name{psm3mkv-package}
 \alias{psm3mkv}
 \alias{psm3mkv-package}
-\title{psm3mkv: Fit and Evaluate Three-State Partitioned Survival Analysis and Markov Models to Progression-Free and Overall Survival data}
+\title{psm3mkv: Fit and Evaluate Three-State Partitioned Survival Analysis and Markov Models to Progression-Free and Overall Survival Data}
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
@@ -13,12 +13,14 @@ Fits and evaluates three-state partitioned survival analyses (PartSAs) and marko
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://merck.github.io/psm3mkv/}
   \item \url{https://github.com/Merck/psm3mkv}
+  \item Report bugs at \url{https://github.com/Merck/psm3mkv/issues}
 }
 
 }
 \author{
-\strong{Maintainer}: Dominic Muston \email{dominic.muston@merck.com} (\href{https://orcid.org/0000000348767940}{ORCID})
+\strong{Maintainer}: Dominic Muston \email{dominic.muston@merck.com} (\href{https://orcid.org/0000-0003-4876-7940}{ORCID})
 
 Other contributors:
 \itemize{


### PR DESCRIPTION
This PR fixes a few R CMD check notes and improves `DESCRIPTION`:

- Correct title case in title
- Correct ORCID format
- Add vignette dependencies to `Suggests`
- Add non-standard top-level files to `.Rbuildignore`
- Add additional URLs that can be displayed in pkgdown site.