### PR TITLE
Prepare for CRAN submission

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^LICENSE\.md$
 ^LICENSES_THIRD_PARTY\.md$
 ^README\.Rmd$
+^cran-comments\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: psm3mkv
 Title: Fit and Evaluate Three-State Partitioned Survival Analysis and Markov Models to Progression-Free and Overall Survival Data
-Version: 0.2.1.9001
+Version: 0.2.1.9002
 Authors@R: c(
     person("Dominic", "Muston", , "dominic.muston@merck.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4876-7940")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Collate: 
     'basics.R'
     'brier.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: psm3mkv
 Title: Fit and Evaluate Three-State Partitioned Survival Analysis and Markov Models to Progression-Free and Overall Survival Data
-Version: 0.2.1.9000
+Version: 0.2.1.9001
 Authors@R: c(
     person("Dominic", "Muston", , "dominic.muston@merck.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4876-7940")),
@@ -41,16 +41,3 @@ VignetteBuilder: knitr
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-Collate: 
-    'basics.R'
-    'brier.R'
-    'datasets.R'
-    'discrmd.R'
-    'fitting-spl.R'
-    'fitting.R'
-    'lhoods.R'
-    'ltablesurv.R'
-    'ppdpps.R'
-    'probgraphs.R'
-    'psm3mkv-package.R'
-    'resmeans.R'

--- a/R/discrmd.R
+++ b/R/discrmd.R
@@ -47,6 +47,7 @@
 #' @seealso [drmd_stm_cf()] [drmd_stm_cr()]
 #' @export
 #' @examples
+#' \donttest{
 #' # Create dataset and fit survival models (splines)
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
@@ -63,6 +64,7 @@
 #' # Add a lifetable constraint
 #' ltable <- tibble::tibble(lttime=0:20, lx=1-lttime*0.05)
 #' drmd_psm(ptdata=bosonc, dpam=params, lifetable=ltable)
+#' }
 drmd_psm <- function(ptdata, dpam, psmtype="simple", Ty=10, discrate=0, lifetable=NA, timestep=1) {
   # Declare local variables
   Tw <- tvec <- pfprob <- osprob <- adjosprob <- adjfac <- adjprob <- vn <- NULL
@@ -96,6 +98,7 @@ drmd_psm <- function(ptdata, dpam, psmtype="simple", Ty=10, discrate=0, lifetabl
 #' @seealso [drmd_psm()] [drmd_stm_cr()]
 #' @export
 #' @examples
+#' \donttest{
 #' # Create dataset and fit survival models (splines)
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
@@ -112,6 +115,7 @@ drmd_psm <- function(ptdata, dpam, psmtype="simple", Ty=10, discrate=0, lifetabl
 #' # Add a lifetable constraint
 #' ltable <- tibble::tibble(lttime=0:20, lx=1-lttime*0.05)
 #' drmd_stm_cf(dpam=params, lifetable=ltable)
+#' }
 drmd_stm_cf <- function(dpam, Ty=10, discrate=0, lifetable=NA, timestep=1) {
   # Declare local variables
   Tw <- tvec <- ppd.ts <- ttp.ts <- pps.ts <- NULsppd <- sttp <- sos <- NULL
@@ -153,6 +157,7 @@ drmd_stm_cf <- function(dpam, Ty=10, discrate=0, lifetable=NA, timestep=1) {
 #' @seealso [drmd_stm_cf()] [drmd_psm()]
 #' @export
 #' @examples
+#' \donttest{
 #' # Create dataset and fit survival models (splines)
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
@@ -166,9 +171,10 @@ drmd_stm_cf <- function(dpam, Ty=10, discrate=0, lifetable=NA, timestep=1) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' drmd_stm_cr(dpam=params)
-#' # Add a lifetable constraint (not run because it's slow)
-#' # ltable <- tibble::tibble(lttime=0:20, lx=1-lttime*0.05)
-#' # drmd_stm_cr(dpam=params, lifetable=ltable)
+#' # Add a lifetable constraint
+#' ltable <- tibble::tibble(lttime=0:20, lx=1-lttime*0.05)
+#' drmd_stm_cr(dpam=params, lifetable=ltable)
+#' }
 drmd_stm_cr <- function(dpam, Ty=10, discrate=0, lifetable=NA, timestep=1) {
   # Declare local variables
   Tw <- tvec <- ppd.ts <- ttp.ts <- sppd <- sttp <- sos <- NULL

--- a/R/fitting-spl.R
+++ b/R/fitting-spl.R
@@ -95,9 +95,11 @@ fit_mods_spl <- function(durn1, durn2=NA, evflag,
 #' @export
 #' @seealso Parametric modeling is handled by [fit_ends_mods_par()]
 #' @examples
+#' \donttest{
 #' # Create dataset in suitable form using bos dataset from the flexsurv package
 #' bosonc <- create_dummydata("flexbosms")
 #' fit_ends_mods_spl(bosonc, expvar=bosonc$ttp.durn)
+#' }
 fit_ends_mods_spl <- function(simdat,
                               knot_set=1:3,
                               scale_set=c("hazard", "odds", "normal"),
@@ -166,9 +168,11 @@ fit_ends_mods_spl <- function(simdat,
 #' @return List of the single survival regression with the best fit.
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' find_bestfit_spl(fits$ttp, "aic")
+#' }
 find_bestfit_spl <- function(reglist, crit="aic") {
   # Declare local variables
   noreg <- valid <- remain <- NULL

--- a/R/lhoods.R
+++ b/R/lhoods.R
@@ -30,9 +30,11 @@
 #' @export
 #' @seealso [flexsurv::flexsurvspline()]
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' convert_fit2spec(fits$pfs[[3]]$result)
+#' }
 convert_fit2spec <- function(fitsurv) {
   # Declare local variables
   par.dist <- type <- spec <- NULL
@@ -84,6 +86,7 @@ convert_fit2spec <- function(fitsurv) {
 #' @importFrom rlang .data
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -96,6 +99,7 @@ convert_fit2spec <- function(fitsurv) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #'   )
 #' calc_likes_psm_simple(bosonc, dpam=params)
+#' }
 calc_likes_psm_simple <- function(ptdata, dpam, cuttime=0) {
   # Declare local variables
   pfs.ts <- pfs.type <- pfs.spec <- pfs.npars <- pfs.durn <- NULL
@@ -382,6 +386,7 @@ calc_likes_stm_cf <- function(ptdata, dpam, cuttime=0) {
 #' @export
 #' @importFrom rlang .data
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -394,6 +399,7 @@ calc_likes_stm_cf <- function(ptdata, dpam, cuttime=0) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #'   )
 #' calc_likes_stm_cr(bosonc, dpam=params)
+#' }
 calc_likes_stm_cr <- function(ptdata, dpam, cuttime=0) {
   # Declare local variables
   ttp.ts <- ttp.type <- ttp.spec <- ttp.npars <- NULL
@@ -494,6 +500,7 @@ calc_likes_stm_cr <- function(ptdata, dpam, cuttime=0) {
 #' @seealso This function calls [calc_likes_psm_simple()], [calc_likes_psm_complex()], [calc_likes_stm_cf()], and [calc_likes_stm_cr()].
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -506,6 +513,7 @@ calc_likes_stm_cr <- function(ptdata, dpam, cuttime=0) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #'   )
 #' calc_likes(bosonc, dpam=params)
+#' }
 calc_likes <- function(ptdata, dpam, cuttime=0) {
   # Declare local variables
   methodnames <- list1 <- list2 <- list3 <- list4 <- methno <- NULL

--- a/R/ppdpps.R
+++ b/R/ppdpps.R
@@ -45,6 +45,7 @@
 #' @return List of pre, the pre-progression hazard, and post, the post-progression hazard
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -58,6 +59,7 @@
 #'   )
 #' calc_haz_psm(0:10, ptdata=bosonc, dpam=params, psmtype="simple")
 #' calc_haz_psm(0:10, ptdata=bosonc, dpam=params, psmtype="complex")
+#' }
 calc_haz_psm <- function(timevar, ptdata, dpam, psmtype) {
   # Declare local variables
   pfs.ts <- pfs.type <- pfs.spec <- NULL
@@ -131,6 +133,7 @@ calc_haz_psm <- function(timevar, ptdata, dpam, psmtype) {
 #' @return Vector of PPS survival function values
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -142,11 +145,12 @@ calc_haz_psm <- function(timevar, ptdata, dpam, psmtype) {
 #'   pps_cf = find_bestfit_spl(fits$pps_cf, "aic")$fit,
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #'   )
-#' # calc_surv_psmpps(totime=1:10,
-#' #   fromtime=rep(1,10),
-#' #   ptdata=bosonc,
-#' #   dpam=params,
-#' #   type="simple")
+#' calc_surv_psmpps(totime=1:10,
+#'   fromtime=rep(1,10),
+#'   ptdata=bosonc,
+#'   dpam=params,
+#'   psmtype="simple")
+#' }
 calc_surv_psmpps <- function(totime, fromtime=0, ptdata, dpam, psmtype="simple") {
   # Declare local variables
   cumH <- NULL

--- a/R/probgraphs.R
+++ b/R/probgraphs.R
@@ -42,6 +42,7 @@
 #' @return Numeric value
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -54,6 +55,7 @@
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_pf_psm(0:100, params)
+#' }
 prob_pf_psm <- function(time, dpam, starting=c(1, 0, 0)) {
   # Declare local variables
   pfs.ts <- survprob <- NULL
@@ -72,6 +74,7 @@ prob_pf_psm <- function(time, dpam, starting=c(1, 0, 0)) {
 #' @return Numeric value
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -84,6 +87,7 @@ prob_pf_psm <- function(time, dpam, starting=c(1, 0, 0)) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_pf_stm(0:100, params)
+#' }
 prob_pf_stm <- function(time, dpam, starting=c(1, 0, 0)) {
   # Declare local variables
   ppd.ts <- s1 <- NULL
@@ -105,6 +109,7 @@ prob_pf_stm <- function(time, dpam, starting=c(1, 0, 0)) {
 #' @return Numeric value
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -117,6 +122,7 @@ prob_pf_stm <- function(time, dpam, starting=c(1, 0, 0)) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_os_psm(0:100, params)
+#' }
 prob_os_psm <- function(time, dpam, starting=c(1, 0, 0)){
   # Declare local variables
   os.ts <- survprob <- NULL
@@ -134,6 +140,7 @@ prob_os_psm <- function(time, dpam, starting=c(1, 0, 0)){
 #' @return Numeric value
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -146,6 +153,7 @@ prob_os_psm <- function(time, dpam, starting=c(1, 0, 0)){
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_pps_cr(0:100, params)
+#' }
 prob_pps_cr <- function(time, dpam) {
   # Declare local variables
   pps.ts <- NULL
@@ -162,6 +170,7 @@ prob_pps_cr <- function(time, dpam) {
 #' @return Vector of the mean probabilities of post-progression survival at each PPS time, averaged over TTP times.
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -174,6 +183,7 @@ prob_pps_cr <- function(time, dpam) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_pps_cf(0:100, 0:100, params)
+#' }
 prob_pps_cf <- function(ttptimes, ppstimes, dpam) {
   # Declare local variables
   pps.ts <- pps.type <- pps.spec <- NULL
@@ -205,6 +215,7 @@ prob_pps_cf <- function(ttptimes, ppstimes, dpam) {
 #' @return Numeric value
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -217,6 +228,7 @@ prob_pps_cf <- function(ttptimes, ppstimes, dpam) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_pd_psm(0:100, params)
+#' }
 prob_pd_psm <- function(time, dpam, starting=c(1, 0, 0)) {
   # Declare local variables
   os <- pf <- NULL
@@ -234,6 +246,7 @@ prob_pd_psm <- function(time, dpam, starting=c(1, 0, 0)) {
 #' @return Numeric value
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -246,6 +259,7 @@ prob_pd_psm <- function(time, dpam, starting=c(1, 0, 0)) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_pd_stm_cr(0:100, params)
+#' }
 prob_pd_stm_cr <- function(time, dpam, starting=c(1, 0, 0)) {
   # Declare local variables
   ttp.ts <- ppd.ts <- pps.ts <- NULL
@@ -281,6 +295,7 @@ prob_pd_stm_cr <- Vectorize(prob_pd_stm_cr, "time")
 #' @return Numeric value
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -293,6 +308,7 @@ prob_pd_stm_cr <- Vectorize(prob_pd_stm_cr, "time")
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_pd_stm_cf(0:100, params)
+#' }
 prob_pd_stm_cf <- function(time, dpam, starting=c(1, 0, 0)) {
   # Declare local variables
   ttp.ts <- ppd.ts <- pps.ts <- NULL
@@ -329,6 +345,7 @@ prob_pd_stm_cf <- Vectorize(prob_pd_stm_cf, "time")
 #' @return Numeric value
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -341,6 +358,7 @@ prob_pd_stm_cf <- Vectorize(prob_pd_stm_cf, "time")
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_os_stm_cr(0:100, params)
+#' }
 prob_os_stm_cr <- function(time, dpam, starting=c(1, 0, 0)) {
   # Declare local variables
   pf <- pd <- NULL
@@ -358,6 +376,7 @@ prob_os_stm_cr <- function(time, dpam, starting=c(1, 0, 0)) {
 #' @return Numeric value
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -370,6 +389,7 @@ prob_os_stm_cr <- function(time, dpam, starting=c(1, 0, 0)) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' prob_os_stm_cf(0:100, params)
+#' }
 prob_os_stm_cf <- function(time, dpam, starting=c(1, 0, 0)) {
   # Declare local variables
   pf <- pd <- NULL
@@ -404,6 +424,7 @@ prob_os_stm_cf <- function(time, dpam, starting=c(1, 0, 0)) {
 #' @export
 #' @importFrom rlang .data
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_par(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -418,6 +439,7 @@ prob_os_stm_cf <- function(time, dpam, starting=c(1, 0, 0)) {
 #' # Create graphics
 #' gs <- graph_survs(ptdata=bosonc, dpam=params)
 #' gs$graph$pd
+#' }
 graph_survs <- function(ptdata, dpam, cuttime=0, tpoints=100){
   cat("Creating KM \n")
   # Declare local variables

--- a/R/resmeans.R
+++ b/R/resmeans.R
@@ -41,6 +41,7 @@
 #' @seealso Used safely as [prmd_pf_stm] by [calc_allrmds]
 #' @export
 #' @examples
+#' \donttest{
 #' # Create dataset and fit survival models (splines)
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
@@ -54,6 +55,7 @@
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' rmd_pf_stm(dpam=params)
+#' }
 rmd_pf_stm <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
   # Declare local variables
   Tw <- ttp.ts <- ppd.ts <- NULL
@@ -90,6 +92,7 @@ prmd_pf_stm <- purrr::possibly(rmd_pf_stm, otherwise=NA_real_)
 #' @export
 #' @seealso Used safely as [prmd_pd_stm_cr] by [calc_allrmds]
 #' @examples
+#' \donttest{
 #' # Create dataset and fit survival models (splines)
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
@@ -103,6 +106,7 @@ prmd_pf_stm <- purrr::possibly(rmd_pf_stm, otherwise=NA_real_)
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' rmd_pd_stm_cr(dpam=params)
+#' }
 rmd_pd_stm_cr <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
   # Declare local variables
   Tw <- ttp.ts <- ppd.ts <- pps.ts <- NULL
@@ -153,6 +157,7 @@ prmd_pd_stm_cr <- purrr::possibly(rmd_pd_stm_cr, otherwise=NA_real_)
 #' @seealso Used safely as [prmd_pd_stm_cf] by [calc_allrmds]
 #' @export
 #' @examples
+#' \donttest{
 #' # Create dataset and fit survival models (splines)
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
@@ -167,6 +172,7 @@ prmd_pd_stm_cr <- purrr::possibly(rmd_pd_stm_cr, otherwise=NA_real_)
 #' )
 #' # Find mean(s)
 #' rmd_pd_stm_cf(dpam=params)
+#' }
 rmd_pd_stm_cf <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
   # Declare local variables
   Tw <- ttp.ts <- ppd.ts <- pps.ts <- NULL
@@ -216,6 +222,7 @@ prmd_pd_stm_cf <- purrr::possibly(rmd_pd_stm_cf, otherwise=NA_real_)
 #' @seealso Used safely as [prmd_pf_psm] by [calc_allrmds]
 #' @export
 #' @examples
+#' \donttest{
 #' # Create dataset and fit survival models (splines)
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
@@ -230,6 +237,7 @@ prmd_pd_stm_cf <- purrr::possibly(rmd_pd_stm_cf, otherwise=NA_real_)
 #' )
 #' # Find mean(s)
 #' rmd_pf_psm(dpam=params)
+#' }
 rmd_pf_psm <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
   # Declare local variables
   Tw <- pfs.ts <- rmd <- NULL
@@ -264,6 +272,7 @@ prmd_pf_psm <- purrr::possibly(rmd_pf_psm, otherwise=NA_real_)
 #' @seealso Used safely as [prmd_os_psm] by [calc_allrmds]
 #' @export
 #' @examples
+#' \donttest{
 #' # Create dataset and fit survival models (splines)
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
@@ -277,6 +286,7 @@ prmd_pf_psm <- purrr::possibly(rmd_pf_psm, otherwise=NA_real_)
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' rmd_os_psm(params)
+#' }
 rmd_os_psm <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
   # Declare local variables
   Tw <- os.ts  <- NULL
@@ -444,6 +454,7 @@ calc_rmd_first <- function(ds, cuttime) {
 #' @seealso Restricted means are provided by [rmd_pf_psm()], [rmd_os_psm()], [rmd_pf_stm()], [rmd_pd_stm_cf()] and [rmd_pd_stm_cr()]. The function [calc_allrmds_boot] provides a version for bootstrapping.
 #' @export
 #' @examples
+#' \donttest{
 #' # Create dataset and fit survival models (splines)
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
@@ -460,6 +471,7 @@ calc_rmd_first <- function(ds, cuttime) {
 #' calc_allrmds(bosonc, dpam=params)
 #' # RMD using discretized ("disc") method, no lifetable constraint
 #' calc_allrmds(bosonc, dpam=params, rmdmethod="disc", timestep=1)
+#' }
 calc_allrmds <- function(ptdata,
                          inclset = 0,
                          dpam,
@@ -531,6 +543,7 @@ calc_allrmds <- function(ptdata,
 #' @return Numeric vector of restricted mean durations - PF for each model (PSM, STM-CF, STM-CR), then PD, then OS.
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -543,6 +556,7 @@ calc_allrmds <- function(ptdata,
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #' )
 #' calc_allrmds_boot(ptdata=bosonc, dpam=params)
+#' }
 calc_allrmds_boot <- function(ptdata,
                               inclset = 0,
                               dpam,

--- a/R/resmeans.R
+++ b/R/resmeans.R
@@ -38,7 +38,6 @@
 #' @param starting Vector of membership probabilities at time zero.
 #' @param discrate Discount rate (%) per year
 #' @return Numeric value in same time unit as patient-level data (weeks).
-#' @include basics.R
 #' @seealso Used safely as [prmd_pf_stm] by [calc_allrmds]
 #' @export
 #' @examples
@@ -80,7 +79,6 @@ rmd_pf_stm <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
 #' Safely calculate restricted mean duration in progression-free for state transition models
 #' @description Calculates the mean duration in the progression-free state for both the state transition clock forward and clock reset models. Requires a carefully formatted list of fitted survival regressions for the necessary endpoints, and the time duration to calculate over. Wrapper with 'possibly' of [rmd_pf_stm]. This function is called by [calc_allrmds].
 #' @param ... Pass-through to [rmd_pf_stm]
-#' @include basics.R
 #' @return Numeric value in same time unit as patient-level data (weeks).
 prmd_pf_stm <- purrr::possibly(rmd_pf_stm, otherwise=NA_real_)
 
@@ -89,7 +87,6 @@ prmd_pf_stm <- purrr::possibly(rmd_pf_stm, otherwise=NA_real_)
 #' @inheritParams rmd_pf_stm
 #' @return Numeric value in same time unit as patient-level data (weeks).
 #' @seealso [rmd_pd_stm_cr]
-#' @include basics.R
 #' @export
 #' @seealso Used safely as [prmd_pd_stm_cr] by [calc_allrmds]
 #' @examples
@@ -147,14 +144,12 @@ rmd_pd_stm_cr <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
 #' @description Calculates the mean duration in the progressed disease state for the clock reset state transition model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over. Wrapper with 'possibly' of [rmd_pd_stm_cr]. This function is called by [calc_allrmds].
 #' @param ... Pass-through to [rmd_pd_stm_cr]
 #' @return Numeric value in same time unit as patient-level data (weeks).
-#' @include basics.R
 prmd_pd_stm_cr <- purrr::possibly(rmd_pd_stm_cr, otherwise=NA_real_)
 
 #' Restricted mean duration in progressed disease state for clock forward state transition model
 #' @description Calculates the mean duration in the progressed disease state for the clock forward state transition model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over.
 #' @inheritParams rmd_pf_stm
 #' @return Numeric value in same time unit as patient-level data (weeks).
-#' @include basics.R
 #' @seealso Used safely as [prmd_pd_stm_cf] by [calc_allrmds]
 #' @export
 #' @examples
@@ -212,7 +207,6 @@ rmd_pd_stm_cf <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
 #' @description Calculates the mean duration in the progressed disease state for the clock forward state transition model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over. Wrapper with 'possibly' of [rmd_pd_stm_cf]. This function is called by [calc_allrmds].
 #' @param ... Pass-through to [rmd_pd_stm_cf]
 #' @return Numeric value in same time unit as patient-level data (weeks).
-#' @include basics.R
 prmd_pd_stm_cf <- purrr::possibly(rmd_pd_stm_cf, otherwise=NA_real_)
 
 #' Restricted mean duration in progression free state for the partitioned survival model
@@ -220,7 +214,6 @@ prmd_pd_stm_cf <- purrr::possibly(rmd_pd_stm_cf, otherwise=NA_real_)
 #' @inheritParams rmd_pf_stm
 #' @return Numeric value in same time unit as patient-level data (weeks).
 #' @seealso Used safely as [prmd_pf_psm] by [calc_allrmds]
-#' @include basics.R
 #' @export
 #' @examples
 #' # Create dataset and fit survival models (splines)
@@ -262,14 +255,12 @@ rmd_pf_psm <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
 #' @description Calculates the mean duration in the progression free state for the partitioned survival model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over. Wrapper with 'possibly' of [rmd_pf_psm]. This function is called by [calc_allrmds].
 #' @param ... Pass-through to [rmd_pf_psm]
 #' @return Numeric value in same time unit as patient-level data (weeks).
-#' @include basics.R
 prmd_pf_psm <- purrr::possibly(rmd_pf_psm, otherwise=NA_real_)
 
 #' Restricted mean duration for overall survival in the partitioned survival model
 #' @description Calculates the mean duration alive (i.e. in either progression free or progressed disease states) for the partitioned survival model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over.
 #' @inheritParams rmd_pf_stm
 #' @return Numeric value in same time unit as patient-level data (weeks).
-#' @include basics.R
 #' @seealso Used safely as [prmd_os_psm] by [calc_allrmds]
 #' @export
 #' @examples
@@ -310,7 +301,6 @@ rmd_os_psm <- function(dpam, Ty=10, starting=c(1, 0, 0), discrate=0) {
 #' @description Calculates the mean duration alive (i.e. in either progression free or progressed disease states) for the partitioned survival model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over. Wrapper with 'possibly' of [rmd_os_psm]. This function is called by [calc_allrmds].
 #' @param ... Pass-through to [rmd_os_psm]
 #' @return Numeric value in same time unit as patient-level data (weeks).
-#' @include basics.R
 prmd_os_psm <- purrr::possibly(rmd_os_psm, otherwise=NA_real_)
 
 #' Fit survival models to each endpoint, given type and spec
@@ -451,7 +441,6 @@ calc_rmd_first <- function(ds, cuttime) {
 #' @return List of detailed numeric results
 #' - cutadj indicates the survival function and area under the curves for PFS and OS up to the cutpoint
 #' - results provides results of the restricted means calculations, by model and state.
-#' @include basics.R
 #' @seealso Restricted means are provided by [rmd_pf_psm()], [rmd_os_psm()], [rmd_pf_stm()], [rmd_pd_stm_cf()] and [rmd_pd_stm_cr()]. The function [calc_allrmds_boot] provides a version for bootstrapping.
 #' @export
 #' @examples
@@ -540,7 +529,6 @@ calc_allrmds <- function(ptdata,
 #' @description Wrapper function to [calc_allrmds] to enable bootstrap sampling of calculations of restricted mean durations for each health state (progression free and progressed disease) for all three models (partitioned survival, clock forward state transition model, clock reset state transition model).
 #' @inheritParams calc_allrmds
 #' @return Numeric vector of restricted mean durations - PF for each model (PSM, STM-CF, STM-CR), then PD, then OS.
-#' @include basics.R
 #' @export
 #' @examples
 #' bosonc <- create_dummydata("flexbosms")

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,16 @@
+## Test environments
+
+* win-builder (devel)
+
+* GitHub Actions
+  * macos-latest (release)
+  * windows-latest release)
+  * ubuntu-latest (devel)
+  * ubuntu-latest (release)
+  * ubuntu-latest (oldrel-1)
+
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+* This is a new release.

--- a/man/calc_allrmds.Rd
+++ b/man/calc_allrmds.Rd
@@ -58,6 +58,7 @@ List of detailed numeric results
 Calculate restricted mean durations for each health state (progression free and progressed disease) for all three models (partitioned survival, clock forward state transition model, clock reset state transition model).
 }
 \examples{
+\donttest{
 # Create dataset and fit survival models (splines)
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
@@ -74,6 +75,7 @@ params <- list(
 calc_allrmds(bosonc, dpam=params)
 # RMD using discretized ("disc") method, no lifetable constraint
 calc_allrmds(bosonc, dpam=params, rmdmethod="disc", timestep=1)
+}
 }
 \seealso{
 Restricted means are provided by \code{\link[=rmd_pf_psm]{rmd_pf_psm()}}, \code{\link[=rmd_os_psm]{rmd_os_psm()}}, \code{\link[=rmd_pf_stm]{rmd_pf_stm()}}, \code{\link[=rmd_pd_stm_cf]{rmd_pd_stm_cf()}} and \code{\link[=rmd_pd_stm_cr]{rmd_pd_stm_cr()}}. The function \link{calc_allrmds_boot} provides a version for bootstrapping.

--- a/man/calc_allrmds_boot.Rd
+++ b/man/calc_allrmds_boot.Rd
@@ -45,6 +45,7 @@ Numeric vector of restricted mean durations - PF for each model (PSM, STM-CF, ST
 Wrapper function to \link{calc_allrmds} to enable bootstrap sampling of calculations of restricted mean durations for each health state (progression free and progressed disease) for all three models (partitioned survival, clock forward state transition model, clock reset state transition model).
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -57,4 +58,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 calc_allrmds_boot(ptdata=bosonc, dpam=params)
+}
 }

--- a/man/calc_haz_psm.Rd
+++ b/man/calc_haz_psm.Rd
@@ -41,6 +41,7 @@ List of pre, the pre-progression hazard, and post, the post-progression hazard
 Derive the hazards of death pre- and post-progression under either simple or complex PSM formulations.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -54,4 +55,5 @@ params <- list(
   )
 calc_haz_psm(0:10, ptdata=bosonc, dpam=params, psmtype="simple")
 calc_haz_psm(0:10, ptdata=bosonc, dpam=params, psmtype="complex")
+}
 }

--- a/man/calc_likes.Rd
+++ b/man/calc_likes.Rd
@@ -62,6 +62,7 @@ The contribution of each patient group to the calculation of log-likelihood for 
 Calculate likelihood values and other summary output for the following three state models structures: partitioned survival, clock forward state transition, and clock reset state transition. The function requires appropriately formatted patient-level data, a set of fitted survival regressions, and the time cut-off (if two-piece modeling is used).
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -74,6 +75,7 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
   )
 calc_likes(bosonc, dpam=params)
+}
 }
 \seealso{
 This function calls \code{\link[=calc_likes_psm_simple]{calc_likes_psm_simple()}}, \code{\link[=calc_likes_psm_complex]{calc_likes_psm_complex()}}, \code{\link[=calc_likes_stm_cf]{calc_likes_stm_cf()}}, and \code{\link[=calc_likes_stm_cr]{calc_likes_stm_cr()}}.

--- a/man/calc_likes_psm_simple.Rd
+++ b/man/calc_likes_psm_simple.Rd
@@ -49,6 +49,7 @@ List of values and data relating to the likelihood for this model:
 Calculate likelihood values and other summary output for a simple three-state partitioned survival model, given appropriately formatted patient-level data, a set of fitted survival regressions, and the time cut-off (if two-piece modeling is used). This function is called by \link{calc_likes}.x three-state partitioned survival model, given appropriately formatted patient-level data, a set of fitted survival regressions, and the time cut-off (if two-piece modeling is used). This function is called by \link{calc_likes}. Unlike \link{calc_likes_psm_complex}, this likelihood function assumes a progression hazard can be derived from the PFS hazard function and the ratio of progression to PFS events from PF patients.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -61,6 +62,7 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
   )
 calc_likes_psm_simple(bosonc, dpam=params)
+}
 }
 \seealso{
 \code{\link[=calc_likes]{calc_likes()}}, \code{\link[=calc_likes_psm_complex]{calc_likes_psm_complex()}}, \code{\link[=calc_likes_stm_cf]{calc_likes_stm_cf()}}, \code{\link[=calc_likes_stm_cr]{calc_likes_stm_cr()}}

--- a/man/calc_likes_stm_cr.Rd
+++ b/man/calc_likes_stm_cr.Rd
@@ -49,6 +49,7 @@ List of values and data relating to the likelihood for this model:
 Calculate likelihood values and other summary output for a three-state clock reset model, given appropriately formatted patient-level data, a set of fitted survival regressions, and the time cut-off (if two-piece modeling is used). This function is called by \link{calc_likes}.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -61,6 +62,7 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
   )
 calc_likes_stm_cr(bosonc, dpam=params)
+}
 }
 \seealso{
 \code{\link[=calc_likes]{calc_likes()}}, \code{\link[=calc_likes_stm_cf]{calc_likes_stm_cf()}}, \code{\link[=calc_likes_psm_simple]{calc_likes_psm_simple()}}, \code{\link[=calc_likes_psm_complex]{calc_likes_psm_complex()}}

--- a/man/calc_surv_psmpps.Rd
+++ b/man/calc_surv_psmpps.Rd
@@ -24,6 +24,7 @@ Vector of PPS survival function values
 Derive the post-progression survival (PPS) function under the simple or complex PSM formulation.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -35,9 +36,10 @@ params <- list(
   pps_cf = find_bestfit_spl(fits$pps_cf, "aic")$fit,
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
   )
-# calc_surv_psmpps(totime=1:10,
-#   fromtime=rep(1,10),
-#   ptdata=bosonc,
-#   dpam=params,
-#   type="simple")
+calc_surv_psmpps(totime=1:10,
+  fromtime=rep(1,10),
+  ptdata=bosonc,
+  dpam=params,
+  psmtype="simple")
+}
 }

--- a/man/convert_fit2spec.Rd
+++ b/man/convert_fit2spec.Rd
@@ -21,9 +21,11 @@ List of type and specification
 Obtain the type and specification as required in other package functions from a model fit
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 convert_fit2spec(fits$pfs[[3]]$result)
+}
 }
 \seealso{
 \code{\link[flexsurv:flexsurvspline]{flexsurv::flexsurvspline()}}

--- a/man/drmd_psm.Rd
+++ b/man/drmd_psm.Rd
@@ -54,6 +54,7 @@ Discretized Restricted Mean Duration calculation for Partitioned Survival Model
 Calculate restricted mean duration (RMD) in PF, PD and OS states under a Partitioned Survival Model structure.
 }
 \examples{
+\donttest{
 # Create dataset and fit survival models (splines)
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
@@ -70,6 +71,7 @@ drmd_psm(ptdata=bosonc, dpam=params)
 # Add a lifetable constraint
 ltable <- tibble::tibble(lttime=0:20, lx=1-lttime*0.05)
 drmd_psm(ptdata=bosonc, dpam=params, lifetable=ltable)
+}
 }
 \seealso{
 \code{\link[=drmd_stm_cf]{drmd_stm_cf()}} \code{\link[=drmd_stm_cr]{drmd_stm_cr()}}

--- a/man/drmd_stm_cf.Rd
+++ b/man/drmd_stm_cf.Rd
@@ -31,6 +31,7 @@ Discretized Restricted Mean Duration calculation for State Transition Model Cloc
 Calculate restricted mean duration (RMD) in PF, PD and OS states under a State Transition Model Clock Forward structure.
 }
 \examples{
+\donttest{
 # Create dataset and fit survival models (splines)
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
@@ -47,6 +48,7 @@ drmd_stm_cf(dpam=params)
 # Add a lifetable constraint
 ltable <- tibble::tibble(lttime=0:20, lx=1-lttime*0.05)
 drmd_stm_cf(dpam=params, lifetable=ltable)
+}
 }
 \seealso{
 \code{\link[=drmd_psm]{drmd_psm()}} \code{\link[=drmd_stm_cr]{drmd_stm_cr()}}

--- a/man/drmd_stm_cr.Rd
+++ b/man/drmd_stm_cr.Rd
@@ -31,6 +31,7 @@ Discretized Restricted Mean Duration calculation for State Transition Model Cloc
 Calculate restricted mean duration (RMD) in PF, PD and OS states under a State Transition Model Clock Reset structure.
 }
 \examples{
+\donttest{
 # Create dataset and fit survival models (splines)
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
@@ -44,9 +45,10 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 drmd_stm_cr(dpam=params)
-# Add a lifetable constraint (not run because it's slow)
-# ltable <- tibble::tibble(lttime=0:20, lx=1-lttime*0.05)
-# drmd_stm_cr(dpam=params, lifetable=ltable)
+# Add a lifetable constraint
+ltable <- tibble::tibble(lttime=0:20, lx=1-lttime*0.05)
+drmd_stm_cr(dpam=params, lifetable=ltable)
+}
 }
 \seealso{
 \code{\link[=drmd_stm_cf]{drmd_stm_cf()}} \code{\link[=drmd_psm]{drmd_psm()}}

--- a/man/find_bestfit_spl.Rd
+++ b/man/find_bestfit_spl.Rd
@@ -18,7 +18,9 @@ List of the single survival regression with the best fit.
 When there are multiple spline models fitted to the same endpoint and dataset, it is necessary to identify the preferred model. This function reviews the fitted regressions and selects that with the minimum Akaike or Bayesian Information Criterion (AIC, BIC), depending on user choice.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 find_bestfit_spl(fits$ttp, "aic")
+}
 }

--- a/man/fit_ends_mods_spl.Rd
+++ b/man/fit_ends_mods_spl.Rd
@@ -43,9 +43,11 @@ Also, the given cuttime.
 Fits multiple survival regressions, according to the distributions stipulated, to the multiple endpoints required in fitting partitioned survival analysis, clock forward and clock reset semi-markov models.
 }
 \examples{
+\donttest{
 # Create dataset in suitable form using bos dataset from the flexsurv package
 bosonc <- create_dummydata("flexbosms")
 fit_ends_mods_spl(bosonc, expvar=bosonc$ttp.durn)
+}
 }
 \seealso{
 Parametric modeling is handled by \code{\link[=fit_ends_mods_par]{fit_ends_mods_par()}}

--- a/man/graph_survs.Rd
+++ b/man/graph_survs.Rd
@@ -41,6 +41,7 @@ Four datasets and graphics as a list
 Graph the observed and fitted state membership probabilities for PF, PD, OS and PPS.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_par(bosonc)
 # Pick out best distribution according to min AIC
@@ -55,4 +56,5 @@ params <- list(
 # Create graphics
 gs <- graph_survs(ptdata=bosonc, dpam=params)
 gs$graph$pd
+}
 }

--- a/man/prob_os_psm.Rd
+++ b/man/prob_os_psm.Rd
@@ -20,6 +20,7 @@ Numeric value
 Calculates membership probability of being alive at a particular time (vectorized), given either state transition model (clock forward or clock reset) with given statistical distributions and parameters. This is the sum of membership probabilities in the progression free and progressed disease states.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -32,4 +33,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_os_psm(0:100, params)
+}
 }

--- a/man/prob_os_stm_cf.Rd
+++ b/man/prob_os_stm_cf.Rd
@@ -20,6 +20,7 @@ Numeric value
 Calculates membership probability of being alive at a given time (vectorized). This probability is from the state transition clock forward model, according to the given statistical distributions and parameters.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -32,4 +33,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_os_stm_cf(0:100, params)
+}
 }

--- a/man/prob_os_stm_cr.Rd
+++ b/man/prob_os_stm_cr.Rd
@@ -20,6 +20,7 @@ Numeric value
 Calculates membership probability of being alive at a given time (vectorized). This probability is from the state transition clock reset model, according to the given statistical distributions and parameters.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -32,4 +33,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_os_stm_cr(0:100, params)
+}
 }

--- a/man/prob_pd_psm.Rd
+++ b/man/prob_pd_psm.Rd
@@ -20,6 +20,7 @@ Numeric value
 Calculates membership probability of having progressed disease at a particular time (vectorized), given the partitioned survival model with certain statistical distributions and parameters.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -32,4 +33,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_pd_psm(0:100, params)
+}
 }

--- a/man/prob_pd_stm_cf.Rd
+++ b/man/prob_pd_stm_cf.Rd
@@ -20,6 +20,7 @@ Numeric value
 Calculates membership probability of the progressed disease state at a given time (vectorized). This probability is from the state transition clock forward model, according to the given statistical distributions and parameters.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -32,4 +33,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_pd_stm_cf(0:100, params)
+}
 }

--- a/man/prob_pd_stm_cr.Rd
+++ b/man/prob_pd_stm_cr.Rd
@@ -20,6 +20,7 @@ Numeric value
 Calculates membership probability of the progressed disease state at a given time (vectorized). This probability is from the state transition clock reset model, according to the given statistical distributions and parameters.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -32,4 +33,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_pd_stm_cr(0:100, params)
+}
 }

--- a/man/prob_pf_psm.Rd
+++ b/man/prob_pf_psm.Rd
@@ -20,6 +20,7 @@ Numeric value
 Calculates membership probability for the progression free state, at a particular time (vectorized), given a partitioned survival model with given statistical distributions and parameters.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -32,4 +33,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_pf_psm(0:100, params)
+}
 }

--- a/man/prob_pf_stm.Rd
+++ b/man/prob_pf_stm.Rd
@@ -20,6 +20,7 @@ Numeric value
 Calculates membership probability for the progression free state, at a particular time (vectorized), given either state transition model (clock forward or clock reset) with given statistical distributions and parameters.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -32,4 +33,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_pf_stm(0:100, params)
+}
 }

--- a/man/prob_pps_cf.Rd
+++ b/man/prob_pps_cf.Rd
@@ -20,6 +20,7 @@ Vector of the mean probabilities of post-progression survival at each PPS time, 
 Calculates probability of post progression survival at a given time from progression (vectorized). This probability is from the state transition clock forward model, according to the given statistical distributions and parameters.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -32,4 +33,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_pps_cf(0:100, 0:100, params)
+}
 }

--- a/man/prob_pps_cr.Rd
+++ b/man/prob_pps_cr.Rd
@@ -18,6 +18,7 @@ Numeric value
 Calculates probability of post progression survival at a given time from progression (vectorized). This probability is from the state transition clock reset model, according to the given statistical distributions and parameters.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -30,4 +31,5 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 prob_pps_cr(0:100, params)
+}
 }

--- a/man/rmd_os_psm.Rd
+++ b/man/rmd_os_psm.Rd
@@ -22,6 +22,7 @@ Numeric value in same time unit as patient-level data (weeks).
 Calculates the mean duration alive (i.e. in either progression free or progressed disease states) for the partitioned survival model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over.
 }
 \examples{
+\donttest{
 # Create dataset and fit survival models (splines)
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
@@ -35,6 +36,7 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 rmd_os_psm(params)
+}
 }
 \seealso{
 Used safely as \link{prmd_os_psm} by \link{calc_allrmds}

--- a/man/rmd_pd_stm_cf.Rd
+++ b/man/rmd_pd_stm_cf.Rd
@@ -22,6 +22,7 @@ Numeric value in same time unit as patient-level data (weeks).
 Calculates the mean duration in the progressed disease state for the clock forward state transition model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over.
 }
 \examples{
+\donttest{
 # Create dataset and fit survival models (splines)
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
@@ -36,6 +37,7 @@ params <- list(
 )
 # Find mean(s)
 rmd_pd_stm_cf(dpam=params)
+}
 }
 \seealso{
 Used safely as \link{prmd_pd_stm_cf} by \link{calc_allrmds}

--- a/man/rmd_pd_stm_cr.Rd
+++ b/man/rmd_pd_stm_cr.Rd
@@ -22,6 +22,7 @@ Numeric value in same time unit as patient-level data (weeks).
 Calculates the mean duration in the progressed disease state for the clock reset state transition model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over.
 }
 \examples{
+\donttest{
 # Create dataset and fit survival models (splines)
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
@@ -35,6 +36,7 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 rmd_pd_stm_cr(dpam=params)
+}
 }
 \seealso{
 \link{rmd_pd_stm_cr}

--- a/man/rmd_pf_psm.Rd
+++ b/man/rmd_pf_psm.Rd
@@ -22,6 +22,7 @@ Numeric value in same time unit as patient-level data (weeks).
 Calculates the mean duration in the progression free state for the partitioned survival model. Requires a carefully formatted list of fitted survival regressions for necessary endpoints, and the time duration to calculate over.
 }
 \examples{
+\donttest{
 # Create dataset and fit survival models (splines)
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
@@ -36,6 +37,7 @@ params <- list(
 )
 # Find mean(s)
 rmd_pf_psm(dpam=params)
+}
 }
 \seealso{
 Used safely as \link{prmd_pf_psm} by \link{calc_allrmds}

--- a/man/rmd_pf_stm.Rd
+++ b/man/rmd_pf_stm.Rd
@@ -22,6 +22,7 @@ Numeric value in same time unit as patient-level data (weeks).
 Calculates the mean duration in the progression-free state for both the state transition clock forward and clock reset models. Requires a carefully formatted list of fitted survival regressions for the necessary endpoints, and the time duration to calculate over.
 }
 \examples{
+\donttest{
 # Create dataset and fit survival models (splines)
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
@@ -35,6 +36,7 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 )
 rmd_pf_stm(dpam=params)
+}
 }
 \seealso{
 Used safely as \link{prmd_pf_stm} by \link{calc_allrmds}

--- a/tests/testthat/test-discrmd.R
+++ b/tests/testthat/test-discrmd.R
@@ -1,6 +1,8 @@
 # Tests for discrmd.R
 # -------------------
 
+skip_on_cran()
+
 # Create dataset
 bosonc <- create_dummydata("flexbosms")
 


### PR DESCRIPTION
I made various changes to prepare for submission to CRAN.

## Documentation

I bumped the roxygen2 version to the latest, 7.3.1. This didn't actually change the `man/` files, but it did remove a warning from `devtools::document()` about using an outdated version.

I removed `@include basics.R` from `resmeans.R`, which removed the `Collate` field from `DESCRIPTION`. Since your package consists entirely of functions, the processing order does not matter. From [Writing R extensions](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file):

> A ‘Collate’ field can be used for controlling the collation order for the R code files in a package when these are processed for package installation.

And from the [roxygen2 documentation](https://roxygen2.r-lib.org/reference/update_collate.html):

> By default, R loads files in alphabetical order. Unfortunately not every alphabet puts letters in the same order, so you can't rely on alphabetic ordering if you need one file loaded before another. (This usually doesn't matter but is important for S4, where you need to make sure that classes are loaded before subclasses and generics are defined before methods.).

And lastly, I explicitly tested this by listing `basics.R` after `resmeans.R` in `Collate`, and all the examples/tests still passed.

I also added `cran-comments.md` (started with [`usethis::use_cran_comments()`](https://usethis.r-lib.org/reference/use_cran_comments.html)). Prior to submitting to CRAN, you'll need to check the package on the CRAN Windows server using `devtools::check_win_devel()`.

A potential blocker. CRAN will flag any URLs it thinks are broken. Unfortunately this is prone to false positives. When I run `urlchecker::url_check()` on my Windows machine, it complains about the following URL:

```R
> urlchecker::url_check()
✖ Error: README.md:163:23 403: Forbidden
    10.1002/sim.1203](https://doi.org/10.1002/sim.1203)
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Error in file(con, "r") : cannot open the connection
In addition: Warning message:
In file(con, "r") :
  cannot open file 'C:\Users\john\repos\psm3mkv/C:/Users/john/repos/psm3mkv/vignettes/example.Rmd': Invalid argument
```

However the URL is valid, https://doi.org/10.1002/sim.1203, and redirects to https://onlinelibrary.wiley.com/doi/10.1002/sim.1203. The URL checker is fine with the latter URL, so you may have to switch to it if the former is flagged by CRAN

## Tests

The tests can't take too long on CRAN. Since there was only one long-running file, `test-discrmd.R`, I simply skipped it

```sh
==> devtools::test()

ℹ Testing psm3mkv
✔ | F W  S  OK | Context
✔ |         67 | basics [1.4s]
✔ |         27 | discrmd [134.4s]
✔ |        153 | fitting-spl [13.6s]
✔ |        114 | fitting [5.7s]
✔ |          8 | lhoods [22.9s]
✔ |         46 | ltablesurv [1.2s]
✔ |         40 | resmeans [23.9s]
```

Note that for your local development, the tests will always be run when using `devtools::test()` and `devtools::check()`. If you want it to run in a non-devtools context, you have to define the environment variable `NOT_CRAN=true` (for example in `~/.Renviron`).

## Examples

The examples are a big potential problem for the CRAN submission because they take so long to run.

My first idea to try is to wrap them in `\donttest{}`.

From [Writing R extensions](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Documenting-functions):

> Finally, there is `\donttest`, used (at the beginning of a separate line) to mark code that should be run by `example()` but not by `R CMD check` (by default: the option `--run-donttest` can be used).

From [DavisVaughan/extrachecks](https://github.com/DavisVaughan/extrachecks):

* You cannot use `\dontrun{}` in examples ([source](https://github.com/DavisVaughan/extrachecks?tab=readme-ov-file#you-used-dontrun-in-an-example-and-got-a-note-about-that))
* You cannot have commented out code lines in examples ([source](https://github.com/DavisVaughan/extrachecks?tab=readme-ov-file#you-get-told-not-to-comment-out-code-in-your-examples-section))

From [ThinkR-open/prepare-for-cran](https://github.com/ThinkR-open/prepare-for-cran)

* Use `\donttest{}` instead of `\dontrun{}` for long-running examples ([source](https://github.com/ThinkR-open/prepare-for-cran?tab=readme-ov-file#long-running-examples))

When I run `R CMD check` locally, the long-running tests are skipped. When I add the flag `--as-cran`, the long-running tests are still run, but they don't generate a NOTE despite taking a long time to run:

```
* checking examples ... [15s] OK
* checking examples with --run-donttest ... [14m] OK
```

I'm hopefully optimistic. However, if the CRAN maintainers object, my suggestion would be to convert the shared (long-running) code below and convert it into an [exported data set](https://r-pkgs.org/data.html#sec-data-data) that can be quickly loaded for examples.

```R
bosonc <- create_dummydata("flexbosms")
fits <- fit_ends_mods_spl(bosonc)
# Pick out best distribution according to min AIC
params <- list(
  ppd = find_bestfit_spl(fits$ppd, "aic")$fit,
  ttp = find_bestfit_spl(fits$ttp, "aic")$fit,
  pfs = find_bestfit_spl(fits$pfs, "aic")$fit,
  os = find_bestfit_spl(fits$os, "aic")$fit,
  pps_cf = find_bestfit_spl(fits$pps_cf, "aic")$fit,
  pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
)
```