### PR TITLE
Fix check notes and extrachecks items

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^LICENSES_THIRD_PARTY\.md$
 ^README\.Rmd$
 ^cran-comments\.md$
+^inst/logo/logo\.R$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -47,3 +47,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -31,7 +31,7 @@ jobs:
           covr::codecov(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
         shell: Rscript {0}
 
@@ -39,12 +39,12 @@ jobs:
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,10 +4,10 @@ Version: 0.2.1.9002
 Authors@R: c(
     person("Dominic", "Muston", , "dominic.muston@merck.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4876-7940")),
-    person("Merck & Co., Inc.", role = c("cph", "fnd"))
+    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = c("cph", "fnd"))
     )
 Description: Fits and evaluates three-state partitioned survival analyses
-    (PartSAs) and markov models (clock forward or clock reset) to
+    (PartSAs) and Markov models (clock forward or clock reset) to
     Progression-Free Survival (PFS) and Overall Survival (OS)
     patient-level data. This data is typically collected in clinical trials
     in oncology. These model structures are typically considered in

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -552,7 +552,7 @@ to the start of each source file to most effectively state the exclusion of warr
 and each file should have at least the “copyright” line and a pointer to
 where the full notice is found.
 
-    Copyright © 2023 Merck & Co., Inc., Rahway, NJ, USA and its affiliates. All rights reserved.
+    Copyright © 2024 Merck & Co., Inc., Rahway, NJ, USA and its affiliates. All rights reserved.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,22 +1,23 @@
-# psm3mkv 0.2.1
+# psm3mkv 0.2.2
 
-# 14 Apr 2024 - Version 0.2.1
+- Fix all `R CMD check` notes.
+
+# psm3mkv 0.2.1 (14 Apr 2024)
 
 Constraining calculations of restricted mean durations and the accompanying `vignette("background-mortality")` has been reworked. The calculations using integral/continuous methods was not reliable. Instead, `calc_allrmds` now has a `rmdmethod="disc"` option to allow for discretized calculations for a given timestep (defaulting at one week). There is a new collection of functions in `discrmd.R` to provide for this, as well as `constrain_survprob()` function, which constrains a vector of survival estimates at given times such that the underlying hazard is at least as great as in an accompanying lifetable.
 
-# 26 Jan 2024 - Version 0.2
+# psm3mkv 0.2.0 (26 Jan 2024)
 
 This version provides additional functionality to the calculation of restricted mean durations in `calc_allrmds`. These estimates may now be constrained by a lifetable (see `calc_ltsurv`) and discounting may now be applied. A vignette describing how to use this functionality is provided: `vignette("background-mortality")`.
 
 There are also some changes to _pkgdown.yml to avoid the theming changes imposed in the 0.6.0 release of bslib 0.6.0, with thanks to @nanxstats.
 
-# 5 Jan 2024 - Version 0.1.1
+# psm3mkv 0.1.1 (5 Jan 2024)
 
 ## Added PSM analysis functions (experimental)
 
-I’ve merged some experimental functions into the main branch following the version 0.1 release package. These functions provide analyses of the constraints on mortality hazards and therefore survival implied by a PSM. They are: `calc_haz_psm()`, `calc_surv_psmpps()`, `pickout_psmhaz`, `graph_psm_hazards()`, and `graph_psm_survs()`.
+Merged some experimental functions into the main branch following the version 0.1 release package. These functions provide analyses of the constraints on mortality hazards and therefore survival implied by a PSM. They are: `calc_haz_psm()`, `calc_surv_psmpps()`, `pickout_psmhaz`, `graph_psm_hazards()`, and `graph_psm_survs()`.
 
-# 1 Jan 2024 - Version 0.1
+# psm3mkv 0.1.0 (1 Jan 2024)
 
 This is the initial release of the package, rather belatedly. The code dates to October 2023.
-

--- a/R/lhoods.R
+++ b/R/lhoods.R
@@ -293,6 +293,7 @@ calc_likes_psm_complex <- function(ptdata, dpam, cuttime=0) {
 #' @importFrom rlang .data
 #' @export
 #' @examples
+#' \donttest{
 #' bosonc <- create_dummydata("flexbosms")
 #' fits <- fit_ends_mods_spl(bosonc)
 #' # Pick out best distribution according to min AIC
@@ -305,6 +306,7 @@ calc_likes_psm_complex <- function(ptdata, dpam, cuttime=0) {
 #'   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
 #'   )
 #' calc_likes_stm_cf(bosonc, dpam=params)
+#' }
 calc_likes_stm_cf <- function(ptdata, dpam, cuttime=0) {
   # Declare local variables
   ttp.ts <- ttp.type <- ttp.spec <- ttp.npars <- NULL

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 coverage](https://codecov.io/gh/Merck/psm3mkv/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Merck/psm3mkv?branch=main)
 <!-- badges: end -->
 
-The goal of *psm3mkv* is to evaluate the efficiency and fit of certain
+The goal of psm3mkv is to evaluate the efficiency and fit of certain
 three state model structures to data typical from an oncology clinical
 trial. The package evaluates the following structures:
 
@@ -19,7 +19,7 @@ trial. The package evaluates the following structures:
 
 The state transition models differ from each other in that the
 transition from progressive disease to death is a function of time from
-baseline in the STM-CF and time from progression in the STM-CR.\[1,2\]
+baseline in the STM-CF and time from progression in the STM-CR [1, 2].
 
 The package requires a patient-level dataset of time to progression
 (TTP), progression-free survival (PFS) and overall survival (OS).
@@ -28,16 +28,14 @@ Given this, the package enables:
 
 - Fitting a range of models to endpoints relevant each model type:
 
-  - One piece parametric (distributions according to
-    [flexsurv](https://cran.r-project.org/package=flexsurv)).
+  - One piece parametric (distributions according to flexsurv.
 
   - Royston-Parmar splines (1-3 internal knots, hazard/odds/normal
-    scales, again as per
-    [flexsurv](https://cran.r-project.org/package=flexsurv))\[3\].
+    scales, again as per flexsurv) [3].
 
   - Two piece parametric (given a time cutoff).
 
-- Selecting the ‘best fit’ survival models for each endpoint (using the
+- Selecting the "best fit" survival models for each endpoint (using the
   Akaike Information Criterion, Bayesian Information Criterion or other
   user preference).
 
@@ -84,9 +82,8 @@ background lifetable.
 
 ## Installation
 
-The package requires version 4.1 of R (due to use of the [native
-pipe](https://www.r-bloggers.com/2021/05/the-new-r-pipe/)). Please
-ensure R is updated first.
+The package requires version R >= 4.1.0 due to use of the native pipe.
+Please ensure R is updated first.
 
 ### Latest stable release
 
@@ -100,7 +97,7 @@ pak::pak("Merck/psm3mkv@*release")
 Note that `pak::pak()` does not build the vignettes by default when
 installing a package from GitHub, which is ideal because the vignettes
 can take a long time to generate. You can conveniently view them on the
-package [webpage](https://merck.github.io/psm3mkv/).
+package [documentation website](https://merck.github.io/psm3mkv/).
 
 ### Development version
 
@@ -123,7 +120,7 @@ pak::pak("Merck/psm3mkv@*release", dependencies = TRUE)
 
 ## Licensing
 
-Copyright (c) 2023 Merck & Co., Inc., Rahway, NJ, USA and its
+Copyright (c) 2024 Merck & Co., Inc., Rahway, NJ, USA and its
 affiliates. All rights reserved.
 
 This file is part of the psm3mkv program.
@@ -146,18 +143,15 @@ different licenses.
 
 ## References
 
-1.  Jackson C, Metcalfe P, Amdahl J, Warkentin MT, Sweeting M,
-    Kunzmann K. flexsurv: Flexible Parametric Survival and Multi-State
-    Models. Available at: <https://cran.r-project.org/package=flexsurv>.
+1. Jackson, Christopher. 2016. "flexsurv: A Platform for Parametric
+   Survival Modeling in R." _Journal of Statistical Software_ 70 (8): 1--33.
 
-2.  Woods BS, Sideris E, Palmer S, Latimer N, Soares M. Partitioned
-    Survival and State Transition Models for Healthcare Decision Making
-    in Oncology: Where Are We Now? Value in Health 23(12):1613-21; 2020.
-    [DOI:
-    10.1016/j.jval.2020.08.2094](https://doi.org/10.1016/j.jval.2020.08.2094)
+2. Woods, Beth S, Eleftherios Sideris, Stephen Palmer, Nick Latimer,
+   and Marta Soares. 2020. "Partitioned Survival and State Transition Models
+   for Healthcare Decision Making in Oncology: Where Are We Now?"
+   _Value in Health_ 23 (12): 1613--1621.
 
-3.  Royston P and Parmar M. Flexible parametric proportional-hazards and
-    proportional-odds models for censored survival data, with
-    application to prognostic modelling and estimation of treatment
-    effects. Statistics in Medicine 21(1):2175-2197; 2002. [DOI:
-    10.1002/sim.1203](https://doi.org/10.1002/sim.1203)
+3. Royston, Patrick, and Mahesh KB Parmar. 2002. "Flexible Parametric
+   Proportional-Hazards and Proportional-Odds Models for Censored Survival
+   Data, with Application to Prognostic Modelling and Estimation of
+   Treatment Effects." _Statistics in Medicine_ 21 (15): 2175--2197.

--- a/inst/logo/logo.R
+++ b/inst/logo/logo.R
@@ -7,6 +7,6 @@ hexSticker::sticker(
   s_x = 0.98, s_y = 0.95, s_width = 1.075, s_height = 1.075,
   package = "", p_x = 1, p_y = 1, p_size = 8, h_size = 1.2, p_family = "pf",
   p_color = "#7B1F58", h_fill = "#EFDBE5", h_color = "#7B1F58",
-  dpi = 640, filename = file.path(tempdir(), "logo.png"),
+  dpi = 640, filename = "man/figures/logo.png",
   white_around_sticker = TRUE
 )

--- a/inst/logo/logo.R
+++ b/inst/logo/logo.R
@@ -2,10 +2,11 @@
 # From hexsticker.png to logo.png
 # With thanks to: https://nanx.me/blog/post/rebranding-r-packages-with-hexagon-stickers/
 
-hexSticker::sticker(subplot="inst/logo/hexsticker.png",
-        s_x = 0.98, s_y = 0.95, s_width = 1.075, s_height = 1.075,
-        package = "", p_x = 1, p_y = 1, p_size = 8, h_size = 1.2, p_family = "pf",
-        p_color = "#7B1F58", h_fill = "#EFDBE5", h_color = "#7B1F58",
-        dpi = 640, filename = "man/figures/logo.png",
-        white_around_sticker = TRUE
-        )
+hexSticker::sticker(
+  subplot = "inst/logo/hexsticker.png",
+  s_x = 0.98, s_y = 0.95, s_width = 1.075, s_height = 1.075,
+  package = "", p_x = 1, p_y = 1, p_size = 8, h_size = 1.2, p_family = "pf",
+  p_color = "#7B1F58", h_fill = "#EFDBE5", h_color = "#7B1F58",
+  dpi = 640, filename = file.path(tempdir(), "logo.png"),
+  white_around_sticker = TRUE
+)

--- a/man/calc_likes_stm_cf.Rd
+++ b/man/calc_likes_stm_cf.Rd
@@ -49,6 +49,7 @@ List of values and data relating to the likelihood for this model:
 Calculate likelihood values and other summary output for a three-state clock forward state transition model, given appropriately formatted patient-level data, a set of fitted survival regressions, and the time cut-off (if two-piece modeling is used). This function is called by \link{calc_likes}.
 }
 \examples{
+\donttest{
 bosonc <- create_dummydata("flexbosms")
 fits <- fit_ends_mods_spl(bosonc)
 # Pick out best distribution according to min AIC
@@ -61,6 +62,7 @@ params <- list(
   pps_cr = find_bestfit_spl(fits$pps_cr, "aic")$fit
   )
 calc_likes_stm_cf(bosonc, dpam=params)
+}
 }
 \seealso{
 \code{\link[=calc_likes]{calc_likes()}}, \code{\link[=calc_likes_psm_simple]{calc_likes_psm_simple()}}, \code{\link[=calc_likes_psm_complex]{calc_likes_psm_complex()}}, \code{\link[=calc_likes_stm_cr]{calc_likes_stm_cr()}}

--- a/man/psm3mkv-package.Rd
+++ b/man/psm3mkv-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Fits and evaluates three-state partitioned survival analyses (PartSAs) and markov models (clock forward or clock reset) to Progression-Free Survival (PFS) and Overall Survival (OS) patient-level data. This data is typically collected in clinical trials in oncology. These model structures are typically considered in cost-effectiveness modeling in advanced/metastatic cancer indications.
+Fits and evaluates three-state partitioned survival analyses (PartSAs) and Markov models (clock forward or clock reset) to Progression-Free Survival (PFS) and Overall Survival (OS) patient-level data. This data is typically collected in clinical trials in oncology. These model structures are typically considered in cost-effectiveness modeling in advanced/metastatic cancer indications.
 }
 \seealso{
 Useful links:
@@ -24,7 +24,7 @@ Useful links:
 
 Other contributors:
 \itemize{
-  \item Merck & Co., Inc. [copyright holder, funder]
+  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates [copyright holder, funder]
 }
 
 }

--- a/vignettes/example.Rmd
+++ b/vignettes/example.Rmd
@@ -1,6 +1,7 @@
 ---
 title: "Example use of psm3mkv"
 output: rmarkdown::html_vignette
+bibliography: psm3mkv.bib
 vignette: >
   %\VignetteIndexEntry{Example use of psm3mkv}
   %\VignetteEngine{knitr::rmarkdown}
@@ -16,9 +17,9 @@ knitr::opts_chunk$set(
 
 ## Introduction
 
-This vignette walks through evaluating the partitioned survival model (PSM) and state transition model structures (either clock reset, STM-CR, or clock forward types, STM-CF) to a dataset derived from the *bosms3* dataset that comes with the [flexsurv::flexsurv-package()].[1] A review of PSMs and STMs in oncology cost-effectiveness models is provided by Woods et al.[2]
+This vignette walks through evaluating the partitioned survival model (PSM) and state transition model structures (either clock reset, STM-CR, or clock forward types, STM-CF) to a dataset derived from the `bosms3` dataset that comes with the flexsurv package [@jackson2016flexsurv]. A review of PSMs and STMs in oncology cost-effectiveness models is provided by @woods2020partitioned.
 
-First we need to load the packages of interest. If you haven't installed *psm3mkv* yet, please see the [installation instructions](https://github.com/Merck/psm3mkv?tab=readme-ov-file#installation) to install it and the other packages required to run the code below.
+First we need to load the packages of interest. If you haven't installed psm3mkv yet, please see the [installation instructions](https://github.com/Merck/psm3mkv?tab=readme-ov-file#installation) to install it and the other packages required to run the code below.
 
 ```{r packages, message=FALSE}
 library("boot")
@@ -29,7 +30,7 @@ library("purrr")
 
 ## Obtaining a suitable dataset
 
-First we create a suitable patient-level dataset using *create_dummydata()*. Here we load data derived from the *bosms3* dataset with the *flexsurv* package.[2]
+First we create a suitable patient-level dataset using `create_dummydata()`. Here we load data derived from the `bosms3` dataset with the flexsurv package [@jackson2016flexsurv].
 
 ```{r dataset}
 # Create and review the dummy dataset
@@ -44,29 +45,31 @@ The dataset contains TTP, PFS and OS data for `r length(bosonc$ptid)` patients.
 
 The three cost-effectiveness model structures we are considering rely on modeling not only of PFS, TTP and OS, but additionally three other endpoints:
 
-* pre-progression death (PPD),
-* post progression survival as a function of time from baseline (known as 'clock forward', PPS-CF), and
-* post-progression survival as a function of time from progression (known as 'clock reset', PPS-CR).
+- Pre-progression death (PPD).
+- Post progression survival as a function of time from baseline (known as 'clock forward', PPS-CF).
+- Post-progression survival as a function of time from progression (known as 'clock reset', PPS-CR).
 
 Once we have a suitable dataset, we will fit statistical models to these six endpoints.
 
 ### Parametric distributions
 
-Let us start by considering parametric distributions. This uses the function *fit_ends_mods_par()*, so called because it cycles through fitting endpoints and models. The original dataset contained only three of these endpoints, the other three endpoints are calculated within the function.
+Let us start by considering parametric distributions. This uses the function `fit_ends_mods_par()`, so called because it cycles through fitting endpoints and models. The original dataset contained only three of these endpoints, the other three endpoints are calculated within the function.
 
 ```{r fit_ends_mods_par}
 # Create a vector of distributions of interest (flexsurv notation)
 alldists <- c("exp", "weibullPH", "llogis", "lnorm", "gamma", "gompertz", "gengamma")
 
 # Fit all distributions to all endpoints (except gengamma to PPD and TTP)
-allfits_par <- fit_ends_mods_par(bosonc,
-                            cuttime=0,
-                            ppd.dist=alldists[1:6],
-                            ttp.dist=alldists[1:6],
-                            pfs.dist=alldists,
-                            os.dist=alldists,
-                            pps_cf.dist=alldists,
-                            pps_cr.dist=alldists)
+allfits_par <- fit_ends_mods_par(
+  bosonc,
+  cuttime = 0,
+  ppd.dist = alldists[1:6],
+  ttp.dist = alldists[1:6],
+  pfs.dist = alldists,
+  os.dist = alldists,
+  pps_cf.dist = alldists,
+  pps_cr.dist = alldists
+)
 
 # Example 1 - PFS endpoint, distribution 2 (weibullPH)
 allfits_par$pfs[[2]]$result
@@ -76,7 +79,7 @@ allfits_par$pps_cf[[3]]$result$res
 allfits_par$pps_cr[[3]]$result$res
 ```
 
-We have fitted multiple parametric distributions to each endpoint. We only need to retain the best-fitting distribution, which we select using *find_bestfit_par()* on the basis of the distribution having the lowest Akaike Information Criterion (AIC).
+We have fitted multiple parametric distributions to each endpoint. We only need to retain the best-fitting distribution, which we select using `find_bestfit_par()` on the basis of the distribution having the lowest Akaike Information Criterion (AIC).
 
 ```{r find_bestfit_par}
 # Pick out best distribution according to min AIC
@@ -93,7 +96,7 @@ fitpar.pfs
 
 ### Royston-Parmar splines models
 
-An alternative approach to parametric modeling is the use of Royston-Parmar splines.[3] We can follow a similar approach, again using *flexsurv* [2] to identify the best-fitting spline distributions. To the six endpoints, we fit 9 spline models: 1, 2 or 3 (internal) knots with either odds, hazard or normal scales. This uses *fit_ends_mods_spl()*.
+An alternative approach to parametric modeling is the use of Royston-Parmar splines [@royston2002flexible]. We can follow a similar approach, again using flexsurv [@jackson2016flexsurv] to identify the best-fitting spline distributions. To the six endpoints, we fit 9 spline models: 1, 2 or 3 (internal) knots with either odds, hazard or normal scales. This uses `fit_ends_mods_spl()`.
 
 ```{r fit_ends_mods_spl}
 # Fit 1-3 knot splines with all 3 scales (odds, hazard, normal) to each endpoint
@@ -105,7 +108,7 @@ allfits_spl$pfs[[2]]$result$aux$scale # Scale
 allfits_spl$pfs[[2]]$result$aux$knots # Knot locations (log time)
 ```
 
-We have fitted multiple splines to each endpoint. We only need to retain the best-fitting distribution, which we select on the basis of the distribution having the lowest Akaike Information Criterion (AIC). We use *find_bestfit_spl()* for this.
+We have fitted multiple splines to each endpoint. We only need to retain the best-fitting distribution, which we select on the basis of the distribution having the lowest Akaike Information Criterion (AIC). We use `find_bestfit_spl()` for this.
 
 ```{r find_bestfit_spl}
 # Pick out best distribution according to min AIC
@@ -126,31 +129,31 @@ Finally, we select our preferred curves for each endpoint. These may or may not 
 
 ```{r bring_together_fits}
 # Bring together our preferred fits for each endpoint in a list
-params <- list(ppd = fitpar.ppd$fit,
-               ttp = fitpar.ttp$fit,
-               pfs = fitspl.pfs$fit,
-               os = fitspl.os$fit,
-               pps_cf = allfits_par$pps_cf[[2]]$result,
-               pps_cr = allfits_spl$pps_cr[[2]]$result
-               )
+params <- list(
+  ppd = fitpar.ppd$fit,
+  ttp = fitpar.ttp$fit,
+  pfs = fitspl.pfs$fit,
+  os = fitspl.os$fit,
+  pps_cf = allfits_par$pps_cf[[2]]$result,
+  pps_cr = allfits_spl$pps_cr[[2]]$result
+)
 ```
 
 Let us count how many parameters we are using in each model.
 
 ```{r count_params}
 # Pull out number of parameters used for each endpoint
-count_npar <- map_vec(1:6, ~params[[.x]]$npars)
+count_npar <- map_vec(1:6, ~ params[[.x]]$npars)
 
 # PSM uses PFS (3) and OS (4) endpoints
-sum(count_npar[c(3,4)])
+sum(count_npar[c(3, 4)])
 
 # STM_CF uses PPD (1), TTP (2) and PPS_CF (5) endpoints
-sum(count_npar[c(1,2,5)])
+sum(count_npar[c(1, 2, 5)])
 
 # STM_CR uses PPD (1), TTP (2) and PPS_CR (6) endpoints
-sum(count_npar[c(1,2,6)])
+sum(count_npar[c(1, 2, 6)])
 ```
-
 
 ## Comparing likelihood values for the three model structures
 
@@ -165,22 +168,23 @@ In this case, the model structures could be fitted to 203 of the 204 patients. A
 
 ## Other measures of goodness of fit
 
-The Brier score is a measure of goodness of fit of a survival model at a particular point in time to a set of patient time-to-event data. Originally developed for measuring the performance of weather forecasting, this metric has since been used in other applications. An extension of the Brier score is the integral of the Brier score, which is an 'area under the curve' measure of concordance of the survival model to a given set of patient time-to-event data. The integral is taken between the minimum and maximum event or censoring times in the dataset. Calculations are provided in the *SurvMetrics* R package, which can be slow to run (about 1 minute in this example).[4]
+The Brier score is a measure of goodness of fit of a survival model at a particular point in time to a set of patient time-to-event data. Originally developed for measuring the performance of weather forecasting, this metric has since been used in other applications. An extension of the Brier score is the integral of the Brier score, which is an 'area under the curve' measure of concordance of the survival model to a given set of patient time-to-event data. The integral is taken between the minimum and maximum event or censoring times in the dataset. Calculations are provided in the R package SurvMetrics, which can be slow to run (about 1 minute in this example, @hanpu2021predictive).
 
-The *psm3mkv* package allows examination of Integrated Brier Scores in the fit of Overall Survival by each of the model structures.
+The psm3mkv package allows examination of Integrated Brier Scores in the fit of Overall Survival by each of the model structures.
 
 ```{r brier}
 # calc_ibs(bosonc, params)
 ```
-In this case, the IBS calculation involved integrating between times 1.18 and 52.70. The PSM had the least IBS and best fit (IBS=0.1771); the two STMs had slightly greater IBS values (0.1773 for CF and 0.1776 for CR).
+
+In this case, the IBS calculation involved integrating between times 1.18 and 52.70. The PSM had the least IBS and best fit (IBS = 0.1771); the two STMs had slightly greater IBS values (0.1773 for CF and 0.1776 for CR).
 
 ## Comparing the implied (restricted) mean durations
 
-In order to understand the degree of structural uncertainty (sensitivity to the choice of model structure), we calculate the (restricted) mean durations in progression-free (PF) and progressed disease (PD) states by model type. To do this, we call the *calc_allrmds()* function with the dataset and statistical distributions we wish to consider for each endpoint. The function also allows specification of the patient subset to use (*inclset*, important for bootstrapping later) and the time horizon. The units for the time horizon are `r round(365.25/7, 2)` times shorter than the units for the output because - the time horizon can be considered to be in units of years, whereas the output is in units of weeks.
+In order to understand the degree of structural uncertainty (sensitivity to the choice of model structure), we calculate the (restricted) mean durations in progression-free (PF) and progressed disease (PD) states by model type. To do this, we call the `calc_allrmds()` function with the dataset and statistical distributions we wish to consider for each endpoint. The function also allows specification of the patient subset to use (`inclset`, important for bootstrapping later) and the time horizon. The units for the time horizon are `r round(365.25/7, 2)` times shorter than the units for the output because - the time horizon can be considered to be in units of years, whereas the output is in units of weeks.
 
 ```{r calc_allrmds}
 # Call the RMD functions
-rmd_all <- calc_allrmds(bosonc, dpam=params)
+rmd_all <- calc_allrmds(bosonc, dpam = params)
 
 # Then review the mean duration in PF, PD and total alive (OS)
 rmd_all$results
@@ -192,15 +196,17 @@ The above output can be bootstrapped to generate standard errors. Here we use ju
 
 ```{r boot, include=FALSE}
 # Bootstrap to calculate SE over R bootstrap samples
-bootlys <- boot(data = bosonc,
-                statistic = calc_allrmds_boot,
-                R = 10,         # Number of simulations
-                cuttime = 0,
-                Ty = 10,
-                dpam = params
-                )
+bootlys <- boot(
+  data = bosonc,
+  statistic = calc_allrmds_boot,
+  R = 10, # Number of simulations
+  cuttime = 0,
+  Ty = 10,
+  dpam = params
+)
 bootlys
 ```
+
 Note that the percentiles information reported indicates that in a small number of samples, the restricted mean duration in PD was restricted to be negative in the PSM. This indicates an inconsistency between the statistical models used in this case for modeling PFS and OS, and may be an additional reason why STMs may be preferred in this case.
 
 ## Visual inspection of model fits
@@ -245,11 +251,3 @@ ptdgraphs$graph$pps + scale_color_npg()
 ```
 
 ## References
-
-1. Jackson C, Metcalfe P, Amdahl J, Warkentin MT, Sweeting M, Kunzmann K. flexsurv: Flexible Parametric Survival and Multi-State Models. Available at: https://cran.r-project.org/package=flexsurv.
-
-2. Woods BS, Sideris E, Palmer S, Latimer N, Soares M. Partitioned Survival and State Transition Models for Healthcare Decision Making in Oncology: Where Are We Now? Value in Health 23(12):1613-21; 2020. [DOI: 10.1016/j.jval.2020.08.2094](https://doi.org/10.1016/j.jval.2020.08.2094)
-
-3. Royston P and Parmar M. Flexible parametric proportional-hazards and proportional-odds models for censored survival data, with application to prognostic modelling and estimation of treatment effects. Statistics in Medicine 21(1):2175-2197; 2002. [DOI: 10.1002/sim.1203](https://doi.org/10.1002/sim.1203)
-
-4. Hanpu Z. Predictive Evaluation Metrics in Survival Analysis. Vignette to the *SurvMetrics* R package. July 2021. Available from: https://cran.r-project.org/package=SurvMetrics/vignettes/SurvMetrics-vignette.html

--- a/vignettes/mortality-adjustments.Rmd
+++ b/vignettes/mortality-adjustments.Rmd
@@ -1,13 +1,11 @@
 ---
 title: "Mortality adjustments"
 output: rmarkdown::html_vignette
+bibliography: psm3mkv.bib
 vignette: >
   %\VignetteIndexEntry{Mortality adjustments}
-  %\VignetteEncoding{UTF-8}
   %\VignetteEngine{knitr::rmarkdown}
-editor_options: 
-  markdown: 
-    wrap: 72
+  %\VignetteEncoding{UTF-8}
 ---
 
 ```{r, include = FALSE}
@@ -19,7 +17,7 @@ knitr::opts_chunk$set(
 
 ## Introduction
 
-This is the second in a series of vignettes illustrating methods for evaluating the fit and efficiency of three state oncology cost-effectiveness model structures, as described in an accompanying journal article.[1] The package is heavily dependent on [flexsurv](https://cran.r-project.org/package=flexsurv)).[2]
+This is the second in a series of vignettes illustrating methods for evaluating the fit and efficiency of three state oncology cost-effectiveness model structures, as described in an accompanying journal article [@muston2024informing]. The package is heavily dependent on flexsurv [@jackson2016flexsurv].
 
 After fitting models, as described in `vignette("example")`, estimates of Restricted Mean Durations (RMDs) in health states can be calculated after constraining for background mortality from a given life table.
 
@@ -56,15 +54,15 @@ $$
 S^{adj}(t) = \min \left[ S(t), S_{gen}(t) \right]
 $$
 
-This is a simple approach, and has been used at least one NICE technology appraisal:
+This is a simple approach, and has been used at least one NICE technology appraisal [@nice2022]:
 
-*"Patient longevity is always the lesser of values generated from the disease-specific survival curve (after adjustment for treatment and functional status) and the survival curve for the general population according to age and sex."[3]*
+> "Patient longevity is always the lesser of values generated from the disease-specific survival curve (after adjustment for treatment and functional status) and the survival curve for the general population according to age and sex."
 
 However, this approach does not ensure that the hazard is at least as great as the hazard of background mortality.
 
 ### Approach 2 - Constraining the hazard function
 
-A more rigorous adjustment would be that the hazard of background mortality acts as a constraint to the unadjusted hazard.[4]
+A more rigorous adjustment would be that the hazard of background mortality acts as a constraint to the unadjusted hazard [@sweeting2023survival].
 
 $$
 h^{adj}(t) = \max \left[ h(t), h_{gen}(t) \right]
@@ -72,11 +70,12 @@ $$
 $$
 \implies S^{adj}(t) = \exp \left[ - \int_0^t h^{adj}(u) du \right]
 $$
+
 In either case, we must assume that the original dataset was NOT subject to background mortality. Although unlikely to be true, this is a common, pragmatic assumption in cost-effectiveness models as long as background mortality is relatively insignificant during trial follow-up.
 
 ### Approach 3 - Modeling excess hazard in the original dataset
 
-The above approaches work by adjusting extrapolations made from models fitted to data assumed to be not subject to background mortality. If - as is likely - the population in the dataset were in fact subject to background mortality, then it would be better to model that dataset using excess hazard methods rather than to seek to make adjustments to extrapolations after the fact. Further discussion of survival extrapolation incorporating general population mortality is provided by Sweeting et al.[4]
+The above approaches work by adjusting extrapolations made from models fitted to data assumed to be not subject to background mortality. If - as is likely - the population in the dataset were in fact subject to background mortality, then it would be better to model that dataset using excess hazard methods rather than to seek to make adjustments to extrapolations after the fact. Further discussion of survival extrapolation incorporating general population mortality is provided by @sweeting2023survival.
 
 ## Application to 3-state State Transition Models (STMs)
 
@@ -93,7 +92,7 @@ Formulas for the mean time in PF and OS are shown in the accompanying article in
 
 This is straightforward enough for the PPD endpoint in the STM-CF and STM-CR structures, and for the PPS endpoint in the STM-CF structure. However matters are more complex for the PPS endpoint for the STM-CF since its hazard and survival are functions of two times (time from progression and time from baseline) rather than just one (time from baseline). This package does not provide integral solutions relying on continuous time for RMDs, and must instead rely on discretization.
 
-Spreadsheet-based economic models almost always rely on discretizing time into timesteps rather than follow the integral formulas described above for continuous time. As long as timesteps are reasonably short, restricted mean duration results should remain reasonably accurate. Derided as a "kludge", half-cycle corrections are nevertheless recommended.[5] The package provides discretized calculations.
+Spreadsheet-based economic models almost always rely on discretizing time into timesteps rather than follow the integral formulas described above for continuous time. As long as timesteps are reasonably short, restricted mean duration results should remain reasonably accurate. Derided as a "kludge", half-cycle corrections are nevertheless recommended [@naimark2013half]. The package provides discretized calculations.
 
 ## Application to Partitioned Survival Models (PSM)
 
@@ -129,18 +128,19 @@ In order to apply constraints to background mortality, we need some background m
 baseage <- 51.0
 
 # Mortality data - England & Wales, Female, 2019
-mort <- readHMDweb(CNTRY="GBRTENW",
-                        item="fltper_1x1",
-                        username="",
-                        password=""
-                        ) |>
-              filter(Year==2019) |>
-              select(Age, lx, dx) |>
-              mutate(Timey = ceiling(Age-baseage)) |>
-              filter(Timey>=0)
+mort <- readHMDweb(
+  CNTRY = "GBRTENW",
+  item = "fltper_1x1",
+  username = "",
+  password = ""
+) |>
+  filter(Year == 2019) |>
+  select(Age, lx, dx) |>
+  mutate(Timey = ceiling(Age - baseage)) |>
+  filter(Timey >= 0)
 
 # The table needs to end with lx=0
-mort <- add_row(mort, Age=111, lx=0, Timey=60)
+mort <- add_row(mort, Age = 111, lx = 0, Timey = 60)
 ```
 
 You will see that the above code cannot run without a login for the [Human Mortality Database](www.mortality.org). Alternatively, we could just make up a mortality table.
@@ -150,8 +150,8 @@ mort <- tibble(
   Timey = 0:30,
   lx = 10000 * exp(-0.03 * Timey^1.1),
   dx = lx - lead(lx),
-  qx = dx/lx
-  )
+  qx = dx / lx
+)
 ```
 
 However we do it, once we have the mortality data, we can apply the SMR ($R$) and derive a lifetable from time zero as required.
@@ -163,14 +163,14 @@ SMR <- 2
 # Recalculate the lifetable with the SMR applied
 mort$adjlx <- mort$lx
 for (i in 2:length(mort$lx)) {
-  mort$adjlx[i] <- mort$adjlx[i-1] * (1 - SMR * mort$qx[i-1])
+  mort$adjlx[i] <- mort$adjlx[i - 1] * (1 - SMR * mort$qx[i - 1])
 }
 
 # Ensure lx>=0
-mort$adjlx[mort$adjlx<0] <- 0
+mort$adjlx[mort$adjlx < 0] <- 0
 
 # Create and view lifetable
-ltable <- tibble(lttime=mort$Timey, lx=mort$adjlx)
+ltable <- tibble(lttime = mort$Timey, lx = mort$adjlx)
 head(ltable)
 ```
 
@@ -203,13 +203,14 @@ fit.pps_cf <- find_bestfit_par(allfits$pps_cf, "aic")
 fit.pps_cr <- find_bestfit_par(allfits$pps_cr, "aic")
 
 # Bring together our preferred fits for each endpoint in a list
-params <- list(ppd = fit.ppd$fit,
-               ttp = fit.ttp$fit,
-               pfs = fit.pfs$fit,
-               os = fit.os$fit,
-               pps_cf = fit.pps_cf$fit,
-               pps_cr = fit.pps_cr$fit
-               )
+params <- list(
+  ppd = fit.ppd$fit,
+  ttp = fit.ttp$fit,
+  pfs = fit.pfs$fit,
+  os = fit.os$fit,
+  pps_cf = fit.pps_cf$fit,
+  pps_cr = fit.pps_cr$fit
+)
 ```
 
 ### Making the projections
@@ -223,25 +224,27 @@ First we derive a projection using integral formulae, without lifetable constrai
 thoz <- 10
 
 # Run the calculations
-proj1 <- calc_allrmds(bosonc, dpam=params, Ty=thoz)
+proj1 <- calc_allrmds(bosonc, dpam = params, Ty = thoz)
 
 # Present the results
-res1 <- proj1$results |> mutate(method="int", lxadj="no", psmmeth="simple")
+res1 <- proj1$results |> mutate(method = "int", lxadj = "no", psmmeth = "simple")
 res1 |> mutate(
-  across(c(pf, pd, os), ~ num(.x, digits = 1)))
+  across(c(pf, pd, os), ~ num(.x, digits = 1))
+)
 ```
 
 Next we derive a projection using a discretization approximation, still without any lifetable constraints.
 
 ```{r proj2}
 # Run the calculation
-proj2 <- calc_allrmds(bosonc, dpam=params, Ty=thoz, rmdmethod="disc")
+proj2 <- calc_allrmds(bosonc, dpam = params, Ty = thoz, rmdmethod = "disc")
 
 # Present the results
 res2 <- proj2$results |>
-  mutate(method="disc", lxadj="no", psmmeth="simple")
+  mutate(method = "disc", lxadj = "no", psmmeth = "simple")
 res2 |> mutate(
-  across(c(pf, pd, os), ~ num(.x, digits = 1)))
+  across(c(pf, pd, os), ~ num(.x, digits = 1))
+)
 ```
 
 Discretization has proven fairly accurate. The STM-CR estimate of mean time alive has reduced by just `r round(res1$os[3]-res2$os[3],1)` weeks for example, from `r round(res1$os[3],1)` to `r round(res2$os[3],1)` weeks.
@@ -250,16 +253,17 @@ Finally, we use a discretization approximation and apply the lifetable constrain
 
 ```{r proj3}
 # Run the calculations
-proj3 <- calc_allrmds(bosonc, dpam=params, Ty=thoz, rmdmethod="disc", lifetable=ltable)
+proj3 <- calc_allrmds(bosonc, dpam = params, Ty = thoz, rmdmethod = "disc", lifetable = ltable)
 
 # Present the results
 res3 <- proj3$results |>
-  mutate(method="disc", lxadj="yes", psmmeth="simple")
+  mutate(method = "disc", lxadj = "yes", psmmeth = "simple")
 res3 |> mutate(
-    across(c(pf, pd, os), ~ num(.x, digits = 1)))
+  across(c(pf, pd, os), ~ num(.x, digits = 1))
+)
 
 # Proportion of time alive spent in PF
-proppf3 <- res3$pf/res3$os
+proppf3 <- res3$pf / res3$os
 ```
 
 There is now a large difference between the STM-CR compared to the STM-CF and PSM structures. All structures estimate fairly similar RMD estimates of being alive (range: `r round(min(res3$os),1)` to `r round(max(res3$os),1)` weeks). The estimate of mean time alive in the STM-CR structure has reduced by `r round(res1$os[3]-res3$os[3],1)` weeks from `r round(res1$os[3],1)` to `r round(res3$os[3],1)` weeks.
@@ -270,19 +274,20 @@ We can check whether using a 'complex' type of PSM structure rather than the def
 
 ```{r proj4}
 # Run the calculations
-proj4 <- calc_allrmds(bosonc, dpam=params, Ty=thoz, psmtype="complex", rmdmethod="disc", lifetable=ltable)
+proj4 <- calc_allrmds(bosonc, dpam = params, Ty = thoz, psmtype = "complex", rmdmethod = "disc", lifetable = ltable)
 
 # Present the results
 res4 <- proj4$results |>
-  mutate(method="disc", lxadj="yes", psmmeth="complex")
+  mutate(method = "disc", lxadj = "yes", psmmeth = "complex")
 res4 |> mutate(
-    across(c(pf, pd, os), ~ num(.x, digits = 1)))
+  across(c(pf, pd, os), ~ num(.x, digits = 1))
+)
 
 # Proportion of time alive spent in PF
-proppf4 <- res4$pf/res4$os
+proppf4 <- res4$pf / res4$os
 ```
 
-All structures estimate fairly similar RMD estimates of being alive (range: `r round(min(res4$os),1)` to `r round(max(res4$os),1)` weeks). The proportion of that time in the PF rather than PD state varied again considerably by model structure (PSM: `r round(100*proppf4[1], 1)`%, STM-CF: `r round(100*proppf4[2], 1)`%, STM-CR: `r round(100*proppf4[3], 1)`%). 
+All structures estimate fairly similar RMD estimates of being alive (range: `r round(min(res4$os),1)` to `r round(max(res4$os),1)` weeks). The proportion of that time in the PF rather than PD state varied again considerably by model structure (PSM: `r round(100*proppf4[1], 1)`%, STM-CF: `r round(100*proppf4[2], 1)`%, STM-CR: `r round(100*proppf4[3], 1)`%).
 
 ### Comparing the results
 
@@ -319,19 +324,7 @@ The change in the RMDs for the 'complex' PSM structure compared to the 'simple' 
 
 ### For further investigation
 
-* The effect of the lifetable constraint on the STMs was much greater - especially to time in the PF state - in the STMs rathe rather than the PSM.
-
-* The package also allows application of discounting through the `discrate` optional call to `calc_allrnds()`.
-
+- The effect of the lifetable constraint on the STMs was much greater - especially to time in the PF state - in the STMs rather than the PSM.
+- The package also allows application of discounting through the `discrate` optional call to `calc_allrnds()`.
 
 ## References
-
-1. Muston D. Informing structural assumptions for three state oncology cost-effectiveness models through model efficiency and fit. In review.
-
-2. Jackson C, Metcalfe P, Amdahl J, Warkentin MT, Sweeting M, Kunzmann K. flexsurv: Flexible Parametric Survival and Multi-State Models. Available at: https://cran.r-project.org/package=flexsurv.
-
-3. National Institute for Health and Care Excellence. Avalglucosidase alfa for treating Pompe disease. Technology appraisal guidance [TA821]. August 24, 2022. Available from: [https://www.nice.org.uk/guidance/ta821/documents/committee-papers](https://www.nice.org.uk/guidance/ta821/documents/committee-papers)
-
-4. Sweeting et al. Survival Extrapolation Incorporating General Population Mortality Using Excess Hazard and Cure Models: A Tutorial. Med Decis Making 2023 Aug;43(6):737-748. [DOI: 10.1177/0272989X231184247](https://doi.org/10.1177/0272989X231184247)
-
-5. Naimark DMJ, Kabboul NN, Krahn MD. The half-cycle correction revisited: redemption of a kludge. Medical Decision Making 2013; 33(7):961-70. [DOI: 10.1177/0272989X13501558](https://doi.org/10.1177/0272989X13501558).

--- a/vignettes/psm3mkv.bib
+++ b/vignettes/psm3mkv.bib
@@ -1,0 +1,78 @@
+@misc{hanpu2021predictive,
+  author       = {Hanpu Zhu},
+  title        = {Predictive Evaluation Metrics in Survival Analysis},
+  year         = {2021},
+  month        = {July},
+  howpublished = {\url{https://cran.r-project.org/package=SurvMetrics/vignettes/SurvMetrics-vignette.html}},
+  note         = {Vignette to the {SurvMetrics} R package}
+}
+
+@article{jackson2016flexsurv,
+  title   = {{flexsurv}: A Platform for Parametric Survival Modeling in {R}},
+  author  = {Christopher Jackson},
+  journal = {Journal of Statistical Software},
+  year    = {2016},
+  volume  = {70},
+  number  = {8},
+  pages   = {1--33}
+}
+
+@unpublished{muston2024informing,
+  author = {Dominic Muston},
+  title  = {Informing structural assumptions for three state oncology cost-effectiveness models through model efficiency and fit},
+  note   = {In review},
+  year   = {2024}
+}
+
+@article{naimark2013half,
+  title   = {The half-cycle correction revisited: redemption of a kludge},
+  author  = {Naimark, David MJ and Kabboul, Nader N and Krahn, Murray D},
+  journal = {Medical Decision Making},
+  volume  = {33},
+  number  = {7},
+  pages   = {961--970},
+  year    = {2013}
+}
+
+@techreport{nice2022,
+  title       = {Avalglucosidase alfa for treating {Pompe} disease},
+  author      = {{National Institute for Health and Care Excellence}},
+  type        = {Technology appraisal guidance},
+  number      = {TA821},
+  year        = {2022},
+  month       = {August},
+  day         = {24},
+  url         = {https://www.nice.org.uk/guidance/ta821/documents/committee-papers},
+  institution = {National Institute for Health and Care Excellence},
+  address     = {London, UK}
+}
+
+@article{royston2002flexible,
+  title   = {Flexible parametric proportional-hazards and proportional-odds models for censored survival data, with application to prognostic modelling and estimation of treatment effects},
+  author  = {Royston, Patrick and Parmar, Mahesh KB},
+  journal = {Statistics in medicine},
+  volume  = {21},
+  number  = {15},
+  pages   = {2175--2197},
+  year    = {2002}
+}
+
+@article{sweeting2023survival,
+  title   = {Survival extrapolation incorporating general population mortality using excess hazard and cure models: a tutorial},
+  author  = {Sweeting, Michael J and Rutherford, Mark J and Jackson, Dan and Lee, Sangyu and Latimer, Nicholas R and Hettle, Robert and Lambert, Paul C},
+  journal = {Medical Decision Making},
+  volume  = {43},
+  number  = {6},
+  pages   = {737--748},
+  year    = {2023}
+}
+
+@article{woods2020partitioned,
+  title   = {Partitioned survival and state transition models for healthcare decision making in oncology: where are we now?},
+  author  = {Woods, Beth S and Sideris, Eleftherios and Palmer, Stephen and Latimer, Nick and Soares, Marta},
+  journal = {Value in Health},
+  volume  = {23},
+  number  = {12},
+  pages   = {1613--1621},
+  year    = {2020}
+}


### PR DESCRIPTION
This PR fixes a few technical details that are likely being flagged in a first CRAN submission:

- Add one more `\donttest` to fix a remaining example running > 5s check note.
- Update copyright year in license file.
- Avoid writing to user directory in the logo generation script (see DavisVaughan/extrachecks #32).

Other quality of life improvements:

- Use BibTeX to manage bibliography for vignettes and run styler on vignettes.
- Format references in `README.md` to be consistent with vignettes.
- Reformat news titles.
- Update GitHub Actions workflows.
- Use proper copyright holder name in `DESCRIPTION`.