### PR TITLE
Add citation section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ coverage](https://codecov.io/gh/Merck/psm3mkv/branch/main/graph/badge.svg)](http
 
 The goal of psm3mkv is to evaluate the efficiency and fit of certain
 three state model structures to data typical from an oncology clinical
-trial, as described in an accompanying article [1]. The package
+trial, as described in an accompanying article (Muston 2024). The package
 evaluates the following structures:
 
 - Partitioned Survival Model/analysis (PSM),
@@ -22,7 +22,8 @@ evaluates the following structures:
 
 The state transition models differ from each other in that the
 transition from progressive disease to death is a function of time from
-baseline in the STM-CF and time from progression in the STM-CR [2, 3].
+baseline in the STM-CF and time from progression in the STM-CR
+(Jackson 2016; Woods et al. 2020).
 
 The package requires a patient-level dataset of time to progression
 (TTP), progression-free survival (PFS) and overall survival (OS).
@@ -34,7 +35,7 @@ Given this, the package enables:
   - One piece parametric (distributions according to flexsurv).
 
   - Royston-Parmar splines (1-3 internal knots, hazard/odds/normal
-    scales, again as per flexsurv) [4].
+    scales, again as per flexsurv) (Royston and Parmar 2002).
 
   - Two piece parametric (given a time cutoff).
 
@@ -114,49 +115,44 @@ package [documentation website](https://merck.github.io/psm3mkv/).
 ### Additional dependencies
 
 Running the vignettes requires additional dependencies, which are all
-either imported by or suggested by *psm3mkv*. Thus you can ensure they
+either imported by or suggested by psm3mkv. Thus you can ensure they
 are all installed by specifying `dependencies = TRUE`.
 
 ``` r
 pak::pak("Merck/psm3mkv@*release", dependencies = TRUE)
 ```
 
-## Licensing
+## Citation
 
-Copyright (c) 2024 Merck & Co., Inc., Rahway, NJ, USA and its
-affiliates. All rights reserved.
+If you use this software, please cite it as below.
 
-This file is part of the psm3mkv program.
+> Muston, D. 2024. "Informing Structural Assumptions for Three State Oncology
+> Cost-Effectiveness Models through Model Efficiency and Fit."
+> _Appl Health Econ Health Policy_. DOI: 10.1007/s40258-024-00884-2
 
-psm3mkv is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your
-option) any later version.
+A BibTeX entry for LaTeX users is
 
-This program is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program. If not, see <http://www.gnu.org/licenses/>.
-
-psm3mkv uses third-party R packages which may be distributed under
-different licenses.
+```bibtex
+@article{muston2024informing,
+  author  = {Dominic Muston},
+  title   = {Informing structural assumptions for three state oncology cost-effectiveness models through model efficiency and fit},
+  journal = {Applied Health Economics and Health Policy},
+  year    = {2024},
+  doi     = {10.1007/s40258-024-00884-2}
+}
+```
 
 ## References
 
-1. Muston, D. 2024. "Informing Structural Assumptions for Three State Oncology Cost-Effectiveness Models through Model Efficiency and Fit." _Appl Health Econ Health Policy_. DOI: 10.1007/s40258-024-00884-2
+Jackson, Christopher. 2016. "flexsurv: A Platform for Parametric
+Survival Modeling in R." _Journal of Statistical Software_ 70 (8): 1--33.
 
-2. Jackson, Christopher. 2016. "flexsurv: A Platform for Parametric
-   Survival Modeling in R." _Journal of Statistical Software_ 70 (8): 1--33.
+Woods, Beth S, Eleftherios Sideris, Stephen Palmer, Nick Latimer,
+and Marta Soares. 2020. "Partitioned Survival and State Transition Models
+for Healthcare Decision Making in Oncology: Where Are We Now?"
+_Value in Health_ 23 (12): 1613--1621.
 
-3. Woods, Beth S, Eleftherios Sideris, Stephen Palmer, Nick Latimer,
-   and Marta Soares. 2020. "Partitioned Survival and State Transition Models
-   for Healthcare Decision Making in Oncology: Where Are We Now?"
-   _Value in Health_ 23 (12): 1613--1621.
-
-4. Royston, Patrick, and Mahesh KB Parmar. 2002. "Flexible Parametric
-   Proportional-Hazards and Proportional-Odds Models for Censored Survival
-   Data, with Application to Prognostic Modelling and Estimation of
-   Treatment Effects." _Statistics in Medicine_ 21 (15): 2175--2197.
+Royston, Patrick, and Mahesh KB Parmar. 2002. "Flexible Parametric
+Proportional-Hazards and Proportional-Odds Models for Censored Survival
+Data, with Application to Prognostic Modelling and Estimation of
+Treatment Effects." _Statistics in Medicine_ 21 (15): 2175--2197.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ If you use this software, please cite it as below.
 
 > Muston, D. 2024. "Informing Structural Assumptions for Three State Oncology
 > Cost-Effectiveness Models through Model Efficiency and Fit."
-> _Appl Health Econ Health Policy_. DOI: 10.1007/s40258-024-00884-2
+> _Applied Health Economics and Health Policy_. DOI: 10.1007/s40258-024-00884-2
 
 A BibTeX entry for LaTeX users is
 

--- a/vignettes/psm3mkv.bib
+++ b/vignettes/psm3mkv.bib
@@ -4,7 +4,7 @@
   year         = {2021},
   month        = {July},
   howpublished = {\url{https://cran.r-project.org/package=SurvMetrics/vignettes/SurvMetrics-vignette.html}},
-  note         = {Vignette to the {SurvMetrics} R package}
+  note         = {Vignette to the {SurvMetrics} {R} package}
 }
 
 @article{jackson2016flexsurv,
@@ -17,12 +17,12 @@
   pages   = {1--33}
 }
 
-@unpublished{muston2024informing,
-  author = {Dominic Muston},
-  title  = {Informing structural assumptions for three state oncology cost-effectiveness models through model efficiency and fit},
+@article{muston2024informing,
+  author  = {Dominic Muston},
+  title   = {Informing structural assumptions for three state oncology cost-effectiveness models through model efficiency and fit},
   journal = {Applied Health Economics and Health Policy},
-  note   = {In press},
-  year   = {2024}
+  year    = {2024},
+  doi     = {10.1007/s40258-024-00884-2}
 }
 
 @article{naimark2013half,
@@ -51,7 +51,7 @@
 @article{royston2002flexible,
   title   = {Flexible parametric proportional-hazards and proportional-odds models for censored survival data, with application to prognostic modelling and estimation of treatment effects},
   author  = {Royston, Patrick and Parmar, Mahesh KB},
-  journal = {Statistics in medicine},
+  journal = {Statistics in Medicine},
   volume  = {21},
   number  = {15},
   pages   = {2175--2197},
@@ -78,53 +78,52 @@
   year    = {2020}
 }
 
- @Manual{pack_dplyr,
-    title = {dplyr: A Grammar of Data Manipulation},
-    author = {Hadley Wickham and Romain François and Lionel Henry and Kirill Müller and Davis Vaughan},
-    year = {2023},
-    note = {R package version 1.1.4},
-    url = {https://CRAN.R-project.org/package=dplyr},
-  }
+ @manual{pack_dplyr,
+  title  = {{dplyr}: A Grammar of Data Manipulation},
+  author = {Hadley Wickham and Romain François and Lionel Henry and Kirill Müller and Davis Vaughan},
+  year   = {2023},
+  note   = {R package version 1.1.4},
+  url    = {https://CRAN.R-project.org/package=dplyr}
+}
 
-@TechReport{pack_HMDHFDplus,
-    author = {Tim Riffe},
-    title = {Reading Human Fertility Database and Human Mortality Database data into R},
-    institution = {MPIDR},
-    year = {2015},
-    url = {https://dx.doi.org/10.4054/MPIDR-TR-2015-004},
-    number = {TR-2015-004},
-    doi = {10.4054/MPIDR-TR-2015-004},
-  }
+@techreport{pack_HMDHFDplus,
+  author      = {Tim Riffe},
+  title       = {Reading Human Fertility Database and Human Mortality Database data into {R}},
+  institution = {MPIDR},
+  year        = {2015},
+  url         = {https://dx.doi.org/10.4054/MPIDR-TR-2015-004},
+  number      = {TR-2015-004},
+  doi         = {10.4054/MPIDR-TR-2015-004}
+}
 
- @Manual{pack_tibble,
-    title = {tibble: Simple Data Frames},
-    author = {Kirill Müller and Hadley Wickham},
-    year = {2023},
-    note = {R package version 3.2.1},
-    url = {https://CRAN.R-project.org/package=tibble},
-  }
+ @manual{pack_tibble,
+  title  = {{tibble}: Simple Data Frames},
+  author = {Kirill Müller and Hadley Wickham},
+  year   = {2023},
+  note   = {R package version 3.2.1},
+  url    = {https://CRAN.R-project.org/package=tibble}
+}
 
-@Manual{pack_boot,
-    title = {boot: Bootstrap R (S-Plus) Functions},
-    author = {{Angelo Canty} and {B. D. Ripley}},
-    year = {2024},
-    note = {R package version 1.3-29},
-  }
+@manual{pack_boot,
+  title  = {boot: Bootstrap {R} ({S-Plus}) Functions},
+  author = {{Angelo Canty} and {B. D. Ripley}},
+  year   = {2024},
+  note   = {{R} package version 1.3-29}
+}
 
-@Manual{pack_ggsci,
-    title = {ggsci: Scientific Journal and Sci-Fi Themed Color Palettes for
-'ggplot2'},
-    author = {Nan Xiao},
-    year = {2024},
-    note = {R package version 3.0.3},
-    url = {https://CRAN.R-project.org/package=ggsci},
-  }
+@manual{pack_ggsci,
+  title  = {{ggsci}: Scientific Journal and Sci-Fi Themed Color Palettes for '{ggplot2}'},
+  author = {Nan Xiao},
+  year   = {2024},
+  note   = {R package version 3.0.3},
+  url    = {https://CRAN.R-project.org/package=ggsci}
+}
 
 
-@Manual{pack_purrr,
-    title = {purrr: Functional Programming Tools},
-    author = {Hadley Wickham and Lionel Henry},
-    year = {2023},
-    note = {R package version 1.0.2},
-    url = {https://CRAN.R-project.org/package=purrr},
-  }
+@manual{pack_purrr,
+  title  = {{purrr}: Functional Programming Tools},
+  author = {Hadley Wickham and Lionel Henry},
+  year   = {2023},
+  note   = {R package version 1.0.2},
+  url    = {https://CRAN.R-project.org/package=purrr}
+}


### PR DESCRIPTION
This PR:

- Have the published paper (Muston 2024) as a dedicated "citation" section in the readme to make it more prominent.
- Removes the "Licensing" section as it's not super canonical and is largely a duplication of copyright text in code.
- Improves BibTeX content and formatting.