### PR TITLE
fix: validate survprob2 length in constrain_survprob

### DIFF
--- a/R/ltablesurv.R
+++ b/R/ltablesurv.R
@@ -191,7 +191,7 @@ constrain_survprob <- function(survprob1, survprob2=NA, lifetable=NA, timevec=0:
   ltexists <- !is.na(lifetable)[1]
   # Survprob1 and survprob2 must have equal length (when survprob2 is defined)
   if(s2exists) {
-    stopifnot("Survival probability vectors must have equal length" = length(survprob1)==length(survprob1))
+    stopifnot("Survival probability vectors must have equal length" = length(survprob1)==length(survprob2))
     }
   # Vector of lifetables (or ones, if lifetable not specified)
   tN <- length(timevec)


### PR DESCRIPTION
Correct the survival-vector length check in constrain_survprob().

The existing guard compares length(survprob1) with itself, so the condition is always TRUE and unequal survprob1 and survprob2 inputs are not rejected.